### PR TITLE
Expand derive vocabulary: each/optional combinators, list & string hygiene, named-format validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
 - Add `@derives` decorator attribute — alternative to inline `derives:` for keeping fields short [#13](https://github.com/mishka-group/guarded_struct/pull/13)
 - Add editor autocomplete inside `guardedstruct do … end` via Spark's ElixirSense plugin (closes [#1](https://github.com/mishka-group/guarded_struct/issues/1)) [#13](https://github.com/mishka-group/guarded_struct/pull/13)
 - Add igniter installer — `mix igniter.install guarded_struct` [#13](https://github.com/mishka-group/guarded_struct/pull/13)
+- Add `each=[ops]` combinator on both sanitize and validate — applies inner ops to every element of a list; validate error message reports failing indices.
+- Add `optional=[ops]` validator wrapper — passes `nil` through, runs inner ops on non-nil values.
+- Add list hygiene sanitizers — `:uniq`, `:compact`, `:reject_empty`, `:sort`.
+- Add string hygiene sanitizers — `:squish` (collapse runs of whitespace + trim), `:no_control` (strip ASCII control chars), `:no_zero_width` (strip zero-width unicode).
+- Add named regex validators — `:slug`, `:hostname`, `:port_number`, `:hex_color`, `:semver`. Patterns are anchored, bounded, and ReDoS-safe; compiled once at module load.
+- Add `{:clamp, [min, max]}` sanitizer — snap out-of-range numbers to the nearest bound.
+- Add `{:default_when_nil, value}` / `{:default_when_empty, value}` sanitizers — fill missing values in the pipeline.
+- Compile-time param shape validation extended to every new parameterised op via `OpParamValidator`.
+- Localised error messages added through the `Messages` callbacks for `slug`, `hostname`, `port_number`, `hex_color`, `semver`, and `each`.
+
 
 ### Refactors:
 
@@ -56,6 +66,8 @@
 - Surface malformed `derives:` strings as `Spark.Error.DslError` with file:line — previously swallowed by a `rescue _ -> nil` and silently produced no validation [#13](https://github.com/mishka-group/guarded_struct/pull/13)
 - Fix re-entrancy in the auto-map cascade — process-dict flag is saved+restored across nested `validate/3` calls so a validator callback can recursively validate without clobbering outer state [#13](https://github.com/mishka-group/guarded_struct/pull/13)
 - Fix `Logger.configure(level: :warning)` global side-effect in `test_helper.exs` — replaced with `@moduletag capture_log: true` on Ash test modules [#13](https://github.com/mishka-group/guarded_struct/pull/13)
+- Parser silently dropped the entire derive string when a `regex=<pattern>` op contained unquoted special characters (`^`, `[`, `+`, `$`, …). Fixed via `quote_regex_values/1` pre-processor that wraps the pattern in `"…"` before AST conversion.
+
 
 ### Tests:
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ field :slug, :string,
 field :slug, :string  
 ```
 
-- 🧼 **Sanitize ops** — `trim`, `upcase`, `downcase`, `capitalize`, `strip_tags`, `basic_html`, `html5`, `tag`, plus user-defined custom ops.
-- ✅ **Validate ops** — `string`, `integer`, `float`, `boolean`, `atom`, `list`, `map`, `tuple`, `record`, `not_empty`, `not_empty_string`, `max_len`, `min_len`, `max`, `min`, `equal`, `uuid`, `email`, `email_r`, `url`, `url_r`, `ipv4`, `ipv6`, `regex`, `enum`, `datetime`, `date`, `time`, `geo`, `location`, plus user-defined.
+- 🧼 **Sanitize ops** — `trim`, `upcase`, `downcase`, `capitalize`, `strip_tags`, `basic_html`, `html5`, `tag`, `squish`, `no_control`, `no_zero_width`, `uniq`, `compact`, `reject_empty`, `sort`, `clamp=[min,max]`, `default_when_nil=v`, `default_when_empty=v`, `each=[ops]`, plus user-defined custom ops.
+- ✅ **Validate ops** — `string`, `integer`, `float`, `boolean`, `atom`, `list`, `map`, `tuple`, `record`, `not_empty`, `not_empty_string`, `max_len`, `min_len`, `max`, `min`, `equal`, `uuid`, `email`, `email_r`, `url`, `ipv4`, `ipv6`, `regex`, `enum`, `datetime`, `date`, `range`, `geo_url`, `location`, `slug`, `hostname`, `port_number`, `hex_color`, `semver`, `optional=[ops]`, `each=[ops]`, plus user-defined.
+- 🧩 **Combinators** — `optional=` wraps any inner ops, passing `nil` through; `each=` runs inner ops over every element of a list.
 - 🎯 **All ops parsed at compile time** — runtime reads pre-built op-maps from `__fields__/0`; zero `Code.eval_string` on the hot path.
 - 🧰 **`@derives` decorator** — alternative to inline `derives:` for keeping fields short.
 

--- a/lib/guarded_struct/derive/op_evaluator.ex
+++ b/lib/guarded_struct/derive/op_evaluator.ex
@@ -84,6 +84,27 @@ defmodule GuardedStruct.Derive.OpEvaluator do
     end
   end
 
+  defp rewrite({:record, tag}) when is_binary(tag), do: {:record, String.to_atom(tag)}
+
+  defp rewrite({:custom, {mods, fun}}) when is_list(mods) and is_atom(fun),
+    do: {:custom, {Module.concat(mods), fun}}
+
+  defp rewrite({:custom, value}) when is_binary(value) do
+    parts =
+      value
+      |> String.replace(["[", "]"], "")
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+
+    case parts do
+      [module_str, fun_str] ->
+        {:custom, {Module.concat([module_str]), String.to_atom(fun_str)}}
+
+      _ ->
+        {:custom, value}
+    end
+  end
+
   defp rewrite(other), do: other
 
   defp strip_close(s) do

--- a/lib/guarded_struct/derive/op_param_validator.ex
+++ b/lib/guarded_struct/derive/op_param_validator.ex
@@ -10,6 +10,8 @@ defmodule GuardedStruct.Derive.OpParamValidator do
   #
   # Bare atoms (e.g. :string, :not_empty) are not param-typed and pass.
 
+  alias GuardedStruct.Derive.Registry
+
   @doc """
   Validate the parameter types of an op-map (`%{validate: [...], sanitize: [...]}`).
   Raises Spark.Error.DslError if anything's off; returns the input unchanged on success.
@@ -107,23 +109,22 @@ defmodule GuardedStruct.Derive.OpParamValidator do
   end
 
   defp check_validate({:optional, list}, field_name, module) when is_list(list),
-    do: Enum.each(list, &check_validate(&1, field_name, module))
+    do: Enum.each(list, &check_combinator_inner(:validate, :optional, &1, field_name, module))
 
-  defp check_validate({:optional, inner}, _f, _m)
-       when is_atom(inner) or is_binary(inner),
-       do: :ok
+  defp check_validate({:optional, inner}, field_name, module) when is_atom(inner),
+    do: check_combinator_inner(:validate, :optional, inner, field_name, module)
 
   defp check_validate({:optional, other}, field_name, module),
     do: bad_param!(:optional, "atom op name or [op, op, …] list", other, field_name, module)
 
   defp check_validate(%{optional: list}, field_name, module) when is_list(list),
-    do: Enum.each(list, &check_validate(&1, field_name, module))
+    do: Enum.each(list, &check_combinator_inner(:validate, :optional, &1, field_name, module))
 
   defp check_validate({:each, list}, field_name, module) when is_list(list),
-    do: Enum.each(list, &check_validate(&1, field_name, module))
+    do: Enum.each(list, &check_combinator_inner(:validate, :each, &1, field_name, module))
 
   defp check_validate(%{each: list}, field_name, module) when is_list(list),
-    do: Enum.each(list, &check_validate(&1, field_name, module))
+    do: Enum.each(list, &check_combinator_inner(:validate, :each, &1, field_name, module))
 
   defp check_validate({:each, other}, field_name, module),
     do: bad_param!(:each, "[op, op, …] list of inner ops", other, field_name, module)
@@ -146,13 +147,56 @@ defmodule GuardedStruct.Derive.OpParamValidator do
   defp check_sanitize({:default_when_nil, _value}, _f, _m), do: :ok
   defp check_sanitize({:default_when_empty, _value}, _f, _m), do: :ok
 
-  defp check_sanitize({:each, list}, _f, _m) when is_list(list), do: :ok
-  defp check_sanitize(%{each: list}, _f, _m) when is_list(list), do: :ok
+  defp check_sanitize({:each, list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_combinator_inner(:sanitize, :each, &1, field_name, module))
+
+  defp check_sanitize(%{each: list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_combinator_inner(:sanitize, :each, &1, field_name, module))
 
   defp check_sanitize({:each, other}, field_name, module),
     do: bad_param!(:each, "[op, op, …] list of inner sanitize ops", other, field_name, module)
 
   defp check_sanitize(_other, _f, _m), do: :ok
+
+  defp check_combinator_inner(side, outer, arg, field_name, module) do
+    case inner_op_name(arg) do
+      nil ->
+        bad_param!(outer, "registered op atom or parameterised op tuple", arg, field_name, module)
+
+      op ->
+        if known_op?(side, op),
+          do: recheck(side, arg, field_name, module),
+          else: bad_inner_op!(side, outer, op, field_name, module)
+    end
+  end
+
+  defp inner_op_name(op) when is_atom(op), do: op
+  defp inner_op_name({op, _}) when is_atom(op), do: op
+
+  defp inner_op_name(%{} = map) when map_size(map) == 1 do
+    case Map.keys(map) do
+      [op] when is_atom(op) -> op
+      _ -> nil
+    end
+  end
+
+  defp inner_op_name(_), do: nil
+
+  defp known_op?(:validate, op), do: Registry.known_validate?(op)
+  defp known_op?(:sanitize, op), do: Registry.known_sanitize?(op)
+
+  defp recheck(:validate, arg, field_name, module), do: check_validate(arg, field_name, module)
+  defp recheck(:sanitize, arg, field_name, module), do: check_sanitize(arg, field_name, module)
+
+  defp bad_inner_op!(side, outer, op, field_name, module) do
+    raise Spark.Error.DslError,
+      message:
+        "unknown #{side} op #{inspect(op)} inside `#{outer}` on field " <>
+          "#{inspect(field_name)}. Register it in GuardedStruct.Derive.Registry " <>
+          "or fix the typo.",
+      path: [:guardedstruct, :field, field_name, :derive],
+      module: module
+  end
 
   defp bad_param!(op, expected, actual, field_name, module) do
     raise Spark.Error.DslError,

--- a/lib/guarded_struct/derive/op_param_validator.ex
+++ b/lib/guarded_struct/derive/op_param_validator.ex
@@ -106,6 +106,28 @@ defmodule GuardedStruct.Derive.OpParamValidator do
     Enum.each(list, &check_validate(&1, field_name, module))
   end
 
+  defp check_validate({:optional, list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_validate(&1, field_name, module))
+
+  defp check_validate({:optional, inner}, _f, _m)
+       when is_atom(inner) or is_binary(inner),
+       do: :ok
+
+  defp check_validate({:optional, other}, field_name, module),
+    do: bad_param!(:optional, "atom op name or [op, op, …] list", other, field_name, module)
+
+  defp check_validate(%{optional: list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_validate(&1, field_name, module))
+
+  defp check_validate({:each, list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_validate(&1, field_name, module))
+
+  defp check_validate(%{each: list}, field_name, module) when is_list(list),
+    do: Enum.each(list, &check_validate(&1, field_name, module))
+
+  defp check_validate({:each, other}, field_name, module),
+    do: bad_param!(:each, "[op, op, …] list of inner ops", other, field_name, module)
+
   defp check_validate(_other, _f, _m), do: :ok
 
   defp check_sanitize({:tag, sub_op}, _f, _m) when is_atom(sub_op) or is_binary(sub_op),
@@ -113,6 +135,22 @@ defmodule GuardedStruct.Derive.OpParamValidator do
 
   defp check_sanitize({:tag, other}, field_name, module),
     do: bad_param!(:tag, "atom (e.g. :strip_tags) or string", other, field_name, module)
+
+  defp check_sanitize({:clamp, [min, max]}, _f, _m)
+       when is_number(min) and is_number(max) and min <= max,
+       do: :ok
+
+  defp check_sanitize({:clamp, other}, field_name, module),
+    do: bad_param!(:clamp, "[min, max] with min <= max (numbers)", other, field_name, module)
+
+  defp check_sanitize({:default_when_nil, _value}, _f, _m), do: :ok
+  defp check_sanitize({:default_when_empty, _value}, _f, _m), do: :ok
+
+  defp check_sanitize({:each, list}, _f, _m) when is_list(list), do: :ok
+  defp check_sanitize(%{each: list}, _f, _m) when is_list(list), do: :ok
+
+  defp check_sanitize({:each, other}, field_name, module),
+    do: bad_param!(:each, "[op, op, …] list of inner sanitize ops", other, field_name, module)
 
   defp check_sanitize(_other, _f, _m), do: :ok
 

--- a/lib/guarded_struct/derive/op_param_validator.ex
+++ b/lib/guarded_struct/derive/op_param_validator.ex
@@ -46,12 +46,14 @@ defmodule GuardedStruct.Derive.OpParamValidator do
   defp check_validate({:tell, other}, field_name, module),
     do: bad_param!(:tell, "integer (country code)", other, field_name, module)
 
+  defp check_validate({:regex, %Regex{}}, _f, _m), do: :ok
+
   defp check_validate({:regex, value}, _f, _m)
        when is_list(value) or is_binary(value),
        do: :ok
 
   defp check_validate({:regex, other}, field_name, module),
-    do: bad_param!(:regex, "charlist or string", other, field_name, module)
+    do: bad_param!(:regex, "charlist, string, or compiled Regex", other, field_name, module)
 
   defp check_validate({:enum, list}, _f, _m) when is_list(list), do: :ok
   defp check_validate({:enum, "String[" <> _}, _f, _m), do: :ok
@@ -97,6 +99,10 @@ defmodule GuardedStruct.Derive.OpParamValidator do
 
   defp check_validate({:custom, {mods, fun}}, _f, _m)
        when is_list(mods) and is_atom(fun),
+       do: :ok
+
+  defp check_validate({:custom, {module, fun}}, _f, _m)
+       when is_atom(module) and is_atom(fun),
        do: :ok
 
   defp check_validate({:custom, value}, _f, _m) when is_binary(value), do: :ok

--- a/lib/guarded_struct/derive/parser.ex
+++ b/lib/guarded_struct/derive/parser.ex
@@ -112,6 +112,12 @@ defmodule GuardedStruct.Derive.Parser do
        when is_atom(key) and is_integer(value),
        do: {key, value}
 
+  defp parse_arg({:=, _, [{:regex, _, nil}, value]}) when is_binary(value),
+    do: precompile_regex(value)
+
+  defp parse_arg({:=, _, [{:regex, _, nil}, value]}) when is_list(value),
+    do: precompile_regex(to_string(value))
+
   defp parse_arg({:=, _, [{key, _, nil}, value]})
        when is_atom(key) and is_binary(value),
        do: {key, value}
@@ -132,6 +138,13 @@ defmodule GuardedStruct.Derive.Parser do
   end
 
   defp parse_arg(_other), do: nil
+
+  defp precompile_regex(source) do
+    case Regex.compile(source) do
+      {:ok, regex} -> {:regex, regex}
+      {:error, _} -> {:regex, source}
+    end
+  end
 
   defp ast_to_string(ast) do
     ast |> Macro.update_meta(fn _ -> [] end) |> Macro.to_string()
@@ -160,42 +173,49 @@ defmodule GuardedStruct.Derive.Parser do
   """
   @spec convert_to_atom_map(
           {:ok, map()} | {:error, any(), any()} | map(),
-          [atom()]
+          [atom()],
+          map() | nil
         ) :: {:error, any(), any()} | map()
-  def convert_to_atom_map(map_or_result, passthrough_keys \\ [])
+  def convert_to_atom_map(map_or_result, passthrough_keys \\ [], atom_lookup \\ nil)
 
-  def convert_to_atom_map({:error, _, _} = error, _), do: error
+  def convert_to_atom_map({:error, _, _} = error, _, _), do: error
 
-  def convert_to_atom_map({:ok, map}, pt) when is_map(map),
-    do: convert_to_atom_map(map, pt)
+  def convert_to_atom_map({:ok, map}, pt, lookup) when is_map(map),
+    do: convert_to_atom_map(map, pt, lookup)
 
-  def convert_to_atom_map(map, pt) when is_struct(map) do
-    do_convert(Map.from_struct(map), pt)
+  def convert_to_atom_map(map, pt, lookup) when is_struct(map) do
+    do_convert(Map.from_struct(map), pt, lookup)
   end
 
-  def convert_to_atom_map(map, pt) when is_map(map) do
-    do_convert(map, pt)
+  def convert_to_atom_map(map, pt, lookup) when is_map(map) do
+    do_convert(map, pt, lookup)
   end
 
-  defp do_convert(map, passthrough_keys) do
+  defp do_convert(map, passthrough_keys, atom_lookup) do
     passthrough = MapSet.new(passthrough_keys)
 
     for {k, v} <- map, into: %{} do
-      atom_key = convert_key(k)
+      atom_key = convert_key(k, atom_lookup)
       new_value = if MapSet.member?(passthrough, atom_key), do: v, else: convert_value(v)
       {atom_key, new_value}
     end
   end
 
-  # Convert binary keys to atoms ONLY if the atom already exists in the
-  # atom table. Unknown / attacker-controlled keys stay as strings.
-  defp convert_key(key) when is_binary(key) do
+  defp convert_key(key, lookup) when is_binary(key) and is_map(lookup) do
+    case Map.fetch(lookup, key) do
+      {:ok, atom} -> atom
+      :error -> safe_to_existing_atom(key)
+    end
+  end
+
+  defp convert_key(key, _lookup) when is_binary(key), do: safe_to_existing_atom(key)
+  defp convert_key(key, _lookup), do: key
+
+  defp safe_to_existing_atom(key) do
     String.to_existing_atom(key)
   rescue
     ArgumentError -> key
   end
-
-  defp convert_key(key), do: key
 
   defp convert_value(%{__struct__: s} = m) when s in [NaiveDateTime, DateTime, Date], do: m
   defp convert_value(%{} = m), do: convert_to_atom_map(m)

--- a/lib/guarded_struct/derive/parser.ex
+++ b/lib/guarded_struct/derive/parser.ex
@@ -100,6 +100,10 @@ defmodule GuardedStruct.Derive.Parser do
   end
 
   defp parse_arg({:=, _, [{key, _, nil}, {value, _, nil}]})
+       when key in [:optional, :each] and is_atom(value),
+       do: {key, [value]}
+
+  defp parse_arg({:=, _, [{key, _, nil}, {value, _, nil}]})
        when is_atom(key) and is_atom(value) do
     {key, Atom.to_string(value)}
   end

--- a/lib/guarded_struct/derive/parser.ex
+++ b/lib/guarded_struct/derive/parser.ex
@@ -29,11 +29,23 @@ defmodule GuardedStruct.Derive.Parser do
     wrapped =
       input
       |> String.trim()
+      |> quote_regex_values()
       |> balance_parens()
       |> String.replace(~r/\)\s+/u, ")\n")
       |> then(&"(\n#{&1}\n)")
 
     Code.string_to_quoted(wrapped, emit_warnings: false)
+  end
+
+  defp quote_regex_values(input) do
+    Regex.replace(~r/(\bregex\s*=\s*)(?!["'])([^,)]+)/u, input, fn _, prefix, pattern ->
+      cleaned =
+        pattern
+        |> String.trim_trailing()
+        |> String.replace(~S("), ~S(\"))
+
+      prefix <> ~s("#{cleaned}")
+    end)
   end
 
   defp balance_parens(input) do

--- a/lib/guarded_struct/derive/registry.ex
+++ b/lib/guarded_struct/derive/registry.ex
@@ -50,7 +50,14 @@ defmodule GuardedStruct.Derive.Registry do
                   :string_float,
                   :string_integer,
                   :some_string_float,
-                  :some_string_integer
+                  :some_string_integer,
+                  :slug,
+                  :hostname,
+                  :port_number,
+                  :hex_color,
+                  :semver,
+                  :optional,
+                  :each
                 ])
 
   @sanitize_ops MapSet.new([
@@ -64,7 +71,18 @@ defmodule GuardedStruct.Derive.Registry do
                   :strip_tags,
                   :tag,
                   :string_float,
-                  :string_integer
+                  :string_integer,
+                  :uniq,
+                  :compact,
+                  :reject_empty,
+                  :sort,
+                  :squish,
+                  :no_control,
+                  :no_zero_width,
+                  :clamp,
+                  :default_when_nil,
+                  :default_when_empty,
+                  :each
                 ])
 
   def validate_ops, do: @validate_ops

--- a/lib/guarded_struct/derive/sanitizer_derive.ex
+++ b/lib/guarded_struct/derive/sanitizer_derive.ex
@@ -11,6 +11,8 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
   @control_chars ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
   @zero_width_chars ~r/[\x{200B}-\x{200D}\x{FEFF}\x{2060}]/u
 
+  @cache_key {__MODULE__, :fallback_module}
+
   @spec call({atom(), any()}, list(any())) :: {any(), any()}
   def call({field, input}, nil), do: {field, input}
 
@@ -177,7 +179,7 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
     do: Enum.reduce(inner_ops, value, fn op, acc -> sanitize(acc, op) end)
 
   defp fallback_dispatch(input, action) do
-    case Application.get_env(:guarded_struct, :sanitize_derive) do
+    case fallback_module() do
       nil ->
         input
 
@@ -188,6 +190,22 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
         derive_module.sanitize(input, action)
     end
   end
+
+  defp fallback_module do
+    raw = Application.get_env(:guarded_struct, :sanitize_derive)
+
+    case :persistent_term.get(@cache_key, :__miss__) do
+      {^raw, cached} ->
+        cached
+
+      _ ->
+        :persistent_term.put(@cache_key, {raw, raw})
+        raw
+    end
+  end
+
+  @doc false
+  def clear_fallback_cache, do: :persistent_term.erase(@cache_key)
 
   defp custom_derive(derive_list, input, action) do
     Enum.reduce_while(derive_list, nil, fn item, _acc ->

--- a/lib/guarded_struct/derive/sanitizer_derive.ex
+++ b/lib/guarded_struct/derive/sanitizer_derive.ex
@@ -7,6 +7,10 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
       # => "hello"
   """
 
+  @squish_runs ~r/\s+/u
+  @control_chars ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/
+  @zero_width_chars ~r/[\x{200B}-\x{200D}\x{FEFF}\x{2060}]/u
+
   @spec call({atom(), any()}, list(any())) :: {any(), any()}
   def call({field, input}, nil), do: {field, input}
 
@@ -94,6 +98,72 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
     end
   end
 
+  def sanitize(input, :uniq) when is_list(input), do: Enum.uniq(input)
+  def sanitize(input, :uniq), do: input
+
+  def sanitize(input, :compact) when is_list(input), do: Enum.reject(input, &is_nil/1)
+  def sanitize(input, :compact), do: input
+
+  def sanitize(input, :reject_empty) when is_list(input) do
+    Enum.reject(input, fn
+      nil -> true
+      "" -> true
+      [] -> true
+      %{} = m when map_size(m) == 0 -> true
+      _ -> false
+    end)
+  end
+
+  def sanitize(input, :reject_empty), do: input
+
+  def sanitize(input, :sort) when is_list(input), do: Enum.sort(input)
+  def sanitize(input, :sort), do: input
+
+  def sanitize(input, :squish) when is_binary(input) do
+    input |> String.replace(@squish_runs, " ") |> String.trim()
+  end
+
+  def sanitize(input, :squish), do: input
+
+  def sanitize(input, :no_control) when is_binary(input),
+    do: String.replace(input, @control_chars, "")
+
+  def sanitize(input, :no_control), do: input
+
+  def sanitize(input, :no_zero_width) when is_binary(input),
+    do: String.replace(input, @zero_width_chars, "")
+
+  def sanitize(input, :no_zero_width), do: input
+
+  def sanitize(input, {:clamp, [min, max]})
+      when is_number(input) and is_number(min) and is_number(max) do
+    cond do
+      input < min -> min
+      input > max -> max
+      true -> input
+    end
+  end
+
+  def sanitize(input, {:clamp, _}), do: input
+
+  def sanitize(nil, {:default_when_nil, value}), do: value
+  def sanitize(input, {:default_when_nil, _}), do: input
+
+  def sanitize(nil, {:default_when_empty, value}), do: value
+  def sanitize("", {:default_when_empty, value}), do: value
+  def sanitize([], {:default_when_empty, value}), do: value
+  def sanitize(%{} = m, {:default_when_empty, value}) when map_size(m) == 0, do: value
+  def sanitize(input, {:default_when_empty, _}), do: input
+
+  def sanitize(input, {:each, inner}) when is_list(input) and is_list(inner),
+    do: Enum.map(input, &apply_each_sanitize(&1, inner))
+
+  def sanitize(input, %{each: inner}) when is_list(input) and is_list(inner),
+    do: Enum.map(input, &apply_each_sanitize(&1, inner))
+
+  def sanitize(input, {:each, _}), do: input
+  def sanitize(input, %{each: _}), do: input
+
   def sanitize(input, action) do
     case GuardedStruct.Derive.Extension.dispatch_sanitize(input, action) do
       :__not_found__ -> fallback_dispatch(input, action)
@@ -102,6 +172,9 @@ defmodule GuardedStruct.Derive.SanitizerDerive do
   rescue
     _ -> input
   end
+
+  defp apply_each_sanitize(value, inner_ops),
+    do: Enum.reduce(inner_ops, value, fn op, acc -> sanitize(acc, op) end)
 
   defp fallback_dispatch(input, action) do
     case Application.get_env(:guarded_struct, :sanitize_derive) do

--- a/lib/guarded_struct/derive/validation_derive.ex
+++ b/lib/guarded_struct/derive/validation_derive.ex
@@ -4,6 +4,11 @@ defmodule GuardedStruct.Derive.ValidationDerive do
 
   @family_alphabet Enum.concat([?a..?z, ~c" "])
 
+  @slug_regex ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/
+  @hostname_regex ~r/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+  @hex_color_regex ~r/^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/
+  @semver_regex ~r/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+
   @spec call({atom(), any()}, list(any()), String.t()) :: {any(), any()}
   def call({_field, input}, nil, _hint), do: {input, []}
 
@@ -586,6 +591,80 @@ defmodule GuardedStruct.Derive.ValidationDerive do
     validate({:record, String.to_atom(tag)}, input, field)
   end
 
+  def validate(:slug, input, field) when is_binary(input) do
+    if Regex.match?(@slug_regex, input),
+      do: input,
+      else: {:error, field, :slug, translated_message(:slug, field)}
+  end
+
+  def validate(:slug, _input, field),
+    do: {:error, field, :slug, translated_message(:slug, field)}
+
+  def validate(:hostname, input, field) when is_binary(input) do
+    if byte_size(input) <= 253 and Regex.match?(@hostname_regex, input),
+      do: input,
+      else: {:error, field, :hostname, translated_message(:hostname, field)}
+  end
+
+  def validate(:hostname, _input, field),
+    do: {:error, field, :hostname, translated_message(:hostname, field)}
+
+  def validate(:port_number, input, _field)
+      when is_integer(input) and input >= 1 and input <= 65535,
+      do: input
+
+  def validate(:port_number, _input, field),
+    do: {:error, field, :port_number, translated_message(:port_number, field)}
+
+  def validate(:hex_color, input, field) when is_binary(input) do
+    if Regex.match?(@hex_color_regex, input),
+      do: input,
+      else: {:error, field, :hex_color, translated_message(:hex_color, field)}
+  end
+
+  def validate(:hex_color, _input, field),
+    do: {:error, field, :hex_color, translated_message(:hex_color, field)}
+
+  def validate(:semver, input, field) when is_binary(input) do
+    if Regex.match?(@semver_regex, input),
+      do: input,
+      else: {:error, field, :semver, translated_message(:semver, field)}
+  end
+
+  def validate(:semver, _input, field),
+    do: {:error, field, :semver, translated_message(:semver, field)}
+
+  def validate({:optional, _inner}, nil, _field), do: nil
+  def validate(%{optional: _inner}, nil, _field), do: nil
+
+  def validate({:optional, inner}, input, field) when is_binary(inner) do
+    run_optional_inner([string_to_op(inner)], input, field)
+  end
+
+  def validate({:optional, inner}, input, field) when is_atom(inner) do
+    run_optional_inner([inner], input, field)
+  end
+
+  def validate({:optional, inner}, input, field) when is_list(inner) do
+    run_optional_inner(inner, input, field)
+  end
+
+  def validate(%{optional: inner}, input, field) when is_list(inner) do
+    run_optional_inner(inner, input, field)
+  end
+
+  def validate({:each, inner}, input, field) when is_list(input) and is_list(inner),
+    do: run_each(input, inner, field)
+
+  def validate(%{each: inner}, input, field) when is_list(input) and is_list(inner),
+    do: run_each(input, inner, field)
+
+  def validate({:each, _}, _input, field),
+    do: {:error, field, :each, translated_message(:each, field)}
+
+  def validate(%{each: _}, _input, field),
+    do: {:error, field, :each, translated_message(:each, field)}
+
   def validate(action, input, field) do
     case GuardedStruct.Derive.Extension.dispatch_validate(action, input, field) do
       :__not_found__ -> fallback_dispatch(action, input, field)
@@ -594,6 +673,51 @@ defmodule GuardedStruct.Derive.ValidationDerive do
   rescue
     _ ->
       {:error, field, :type, translated_message(:validate_unexpected, field)}
+  end
+
+  defp run_optional_inner(inner_ops, input, field) do
+    Enum.reduce_while(inner_ops, input, fn op, _acc ->
+      case validate(op, input, field) do
+        {:error, _, _, _} = err -> {:halt, err}
+        {:error, _, _, _, _} = err -> {:halt, err}
+        _ok -> {:cont, input}
+      end
+    end)
+  end
+
+  defp run_each(input, inner_ops, field) do
+    bad_indices =
+      input
+      |> Enum.with_index()
+      |> Enum.reduce([], fn {elem, idx}, acc ->
+        if each_element_ok?(elem, inner_ops, field), do: acc, else: [idx | acc]
+      end)
+      |> Enum.reverse()
+
+    case bad_indices do
+      [] ->
+        input
+
+      _ ->
+        {:error, field, :each,
+         translated_message(:each, field) <> " (failed indices: #{inspect(bad_indices)})"}
+    end
+  end
+
+  defp each_element_ok?(elem, inner_ops, field) do
+    Enum.all?(inner_ops, fn op ->
+      case validate(op, elem, field) do
+        {:error, _, _, _} -> false
+        {:error, _, _, _, _} -> false
+        _ -> true
+      end
+    end)
+  end
+
+  defp string_to_op(bin) when is_binary(bin) do
+    String.to_existing_atom(bin)
+  rescue
+    _ -> bin
   end
 
   defp fallback_dispatch(action, input, field) do

--- a/lib/guarded_struct/derive/validation_derive.ex
+++ b/lib/guarded_struct/derive/validation_derive.ex
@@ -9,6 +9,8 @@ defmodule GuardedStruct.Derive.ValidationDerive do
   @hex_color_regex ~r/^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/
   @semver_regex ~r/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
 
+  @cache_key {__MODULE__, :fallback_module}
+
   @spec call({atom(), any()}, list(any()), String.t()) :: {any(), any()}
   def call({_field, input}, nil, _hint), do: {input, []}
 
@@ -326,6 +328,12 @@ defmodule GuardedStruct.Derive.ValidationDerive do
       {:error, field, :date, translated_message(:date_binary, field)}
   end
 
+  def validate({:regex, %Regex{} = regex}, input, field) when is_binary(input) do
+    if Regex.match?(regex, input),
+      do: input,
+      else: {:error, field, :regex, translated_message(:regex, field)}
+  end
+
   # All the regex that you want to use should put inside '' and see the result before using.
   def validate({:regex, pattern_str}, input, field)
       when is_binary(input) and is_list(pattern_str) do
@@ -491,7 +499,16 @@ defmodule GuardedStruct.Derive.ValidationDerive do
     |> vlidate_equal(input, field)
   end
 
-  def validate({:custom, {module_list, function}}, input, field) do
+  def validate({:custom, {module, function}}, input, field)
+      when is_atom(module) and is_atom(function) do
+    executed = apply(module, function, [input])
+    if is_boolean(executed) and executed, do: input, else: raise(ArgumentError, "")
+  rescue
+    _e ->
+      {:error, field, :custom, translated_message(:custom, field)}
+  end
+
+  def validate({:custom, {module_list, function}}, input, field) when is_list(module_list) do
     safe_module = Module.safe_concat(module_list)
     executed = apply(safe_module, function, [input])
     if is_boolean(executed) and executed, do: input, else: raise(ArgumentError, "")
@@ -711,7 +728,7 @@ defmodule GuardedStruct.Derive.ValidationDerive do
   end
 
   defp fallback_dispatch(action, input, field) do
-    case Application.get_env(:guarded_struct, :validate_derive) do
+    case fallback_module() do
       nil ->
         {:error, field, :type, translated_message(:validate_unexpected, field)}
 
@@ -722,6 +739,22 @@ defmodule GuardedStruct.Derive.ValidationDerive do
         derive_module.validate(action, input, field)
     end
   end
+
+  defp fallback_module do
+    raw = Application.get_env(:guarded_struct, :validate_derive)
+
+    case :persistent_term.get(@cache_key, :__miss__) do
+      {^raw, cached} ->
+        cached
+
+      _ ->
+        :persistent_term.put(@cache_key, {raw, raw})
+        raw
+    end
+  end
+
+  @doc false
+  def clear_fallback_cache, do: :persistent_term.erase(@cache_key)
 
   if Code.ensure_loaded?(URL) do
     defp location(geo_link, field, action) do

--- a/lib/guarded_struct/derive/validation_derive.ex
+++ b/lib/guarded_struct/derive/validation_derive.ex
@@ -637,10 +637,6 @@ defmodule GuardedStruct.Derive.ValidationDerive do
   def validate({:optional, _inner}, nil, _field), do: nil
   def validate(%{optional: _inner}, nil, _field), do: nil
 
-  def validate({:optional, inner}, input, field) when is_binary(inner) do
-    run_optional_inner([string_to_op(inner)], input, field)
-  end
-
   def validate({:optional, inner}, input, field) when is_atom(inner) do
     run_optional_inner([inner], input, field)
   end
@@ -712,12 +708,6 @@ defmodule GuardedStruct.Derive.ValidationDerive do
         _ -> true
       end
     end)
-  end
-
-  defp string_to_op(bin) when is_binary(bin) do
-    String.to_existing_atom(bin)
-  rescue
-    _ -> bin
   end
 
   defp fallback_dispatch(action, input, field) do

--- a/lib/guarded_struct/info.ex
+++ b/lib/guarded_struct/info.ex
@@ -211,8 +211,8 @@ defmodule GuardedStruct.Info do
       #=> MyApp.User.Address
   """
   def sub_module(module, name) when is_atom(name) do
-    case field_kind(module, name) do
-      :sub_field -> Module.concat(module, Codegen.atom_to_module(name))
+    case module.__field_meta__(name) do
+      %{kind: :sub_field, child_module: child} -> child
       _ -> nil
     end
   end
@@ -316,11 +316,8 @@ defmodule GuardedStruct.Info do
 
     case meta.kind do
       :sub_field ->
-        Map.put(
-          base,
-          :sub_module,
-          Module.concat(parent_module, Codegen.atom_to_module(meta.name))
-        )
+        (meta[:child_module] || Module.concat(parent_module, Codegen.atom_to_module(meta.name)))
+        |> then(&Map.put(base, :sub_module, &1))
 
       _ ->
         base

--- a/lib/guarded_struct/runtime.ex
+++ b/lib/guarded_struct/runtime.ex
@@ -283,9 +283,12 @@ defmodule GuardedStruct.Runtime do
     enforce_keys = info.enforce_keys
     dynamic_field_names = Map.get(info, :dynamic_keys, [])
 
-    full_attrs_atomized = Parser.convert_to_atom_map(full_attrs, dynamic_field_names)
+    full_attrs_atomized =
+      full_attrs
+      |> Parser.convert_to_atom_map(dynamic_field_names, module.__guarded_atom_lookup__())
 
-    with {:ok, normalized} <- normalize_keys(attrs, dynamic_field_names),
+    with {:ok, normalized} <-
+           normalize_keys(attrs, dynamic_field_names, module.__guarded_atom_lookup__()),
          {:ok, attrs_after_authorized} <-
            authorized_fields(normalized, keys, section_opts.authorized_fields),
          :ok <- check_enforce_keys(attrs_after_authorized, enforce_keys),
@@ -380,10 +383,10 @@ defmodule GuardedStruct.Runtime do
     Map.get(info, :options, %{authorized_fields: false})
   end
 
-  defp normalize_keys(attrs, dynamic_field_names) when is_map(attrs) do
+  defp normalize_keys(attrs, dynamic_field_names, atom_lookup) when is_map(attrs) do
     case Map.keys(attrs) |> List.first() do
       nil -> {:ok, attrs}
-      _ -> {:ok, Parser.convert_to_atom_map(attrs, dynamic_field_names)}
+      _ -> {:ok, Parser.convert_to_atom_map(attrs, dynamic_field_names, atom_lookup)}
     end
   end
 
@@ -726,12 +729,11 @@ defmodule GuardedStruct.Runtime do
         build_single(meta.struct, meta.name, value, ok_acc, err_acc, full_attrs, parent_path)
 
       meta.kind == :sub_field and Map.get(meta, :list?) == true and is_list(value) ->
-        submodule = Module.concat(parent_module, atom_to_module(meta.name))
-        build_list(submodule, meta.name, value, ok_acc, err_acc, full_attrs, parent_path)
+        build_list(meta.child_module, meta.name, value, ok_acc, err_acc, full_attrs, parent_path)
 
       meta.kind == :sub_field and is_map(value) ->
-        submodule = Module.concat(parent_module, atom_to_module(meta.name))
-        build_single(submodule, meta.name, value, ok_acc, err_acc, full_attrs, parent_path)
+        meta.child_module
+        |> build_single(meta.name, value, ok_acc, err_acc, full_attrs, parent_path)
 
       true ->
         {:ok, ok_acc, err_acc}
@@ -1215,7 +1217,7 @@ defmodule GuardedStruct.Runtime do
   def all_keys(module) do
     Enum.map(module.__information__().keys, fn k ->
       case module.__field_meta__(k) do
-        %{kind: :sub_field} -> %{k => all_keys(Module.concat(module, atom_to_module(k)))}
+        %{kind: :sub_field, child_module: child} -> %{k => all_keys(child)}
         _ -> k
       end
     end)
@@ -1225,7 +1227,7 @@ defmodule GuardedStruct.Runtime do
   def all_enforce_keys(module) do
     Enum.flat_map(module.__information__().enforce_keys, fn k ->
       case module.__field_meta__(k) do
-        %{kind: :sub_field} -> [%{k => all_keys(Module.concat(module, atom_to_module(k)))}]
+        %{kind: :sub_field, child_module: child} -> [%{k => all_keys(child)}]
         _ -> [k]
       end
     end)

--- a/lib/guarded_struct/transformers/codegen.ex
+++ b/lib/guarded_struct/transformers/codegen.ex
@@ -63,8 +63,6 @@ defmodule GuardedStruct.Transformers.Codegen do
     {keys, defstruct_kw, types, enforce_keys, fields_runtime} =
       build_struct_pieces(entities, block_enforce)
 
-    field_meta_map = Map.new(fields_runtime, fn m -> {m.name, m} end)
-
     json? = Map.get(options, :json, false) == true
 
     # `json: true` opts into JSON encoding. Precedence:
@@ -159,13 +157,19 @@ defmodule GuardedStruct.Transformers.Codegen do
         Map.put(unquote(info_map), :module, __MODULE__)
       end
 
-      def __fields__, do: unquote(Macro.escape(fields_runtime))
+      @__guarded_fields__ GuardedStruct.Transformers.Codegen.bake_child_modules(
+                            unquote(Macro.escape(fields_runtime)),
+                            __MODULE__
+                          )
+      def __fields__, do: @__guarded_fields__
 
-      def __field_meta__(name), do: Map.get(unquote(Macro.escape(field_meta_map)), name)
+      @__guarded_field_meta_map__ Map.new(@__guarded_fields__, fn m -> {m.name, m} end)
+      def __field_meta__(name), do: Map.get(@__guarded_field_meta_map__, name)
 
       def __guarded_information__, do: __information__()
       def __guarded_fields__, do: __fields__()
       def __guarded_field_meta__(name), do: __field_meta__(name)
+      def __guarded_atom_lookup__, do: unquote(Macro.escape(atom_lookup_for(keys)))
 
       @__guarded_has_validator__ Module.defines?(__MODULE__, {:validator, 2}, :def)
       def __guarded_has_validator__, do: @__guarded_has_validator__
@@ -261,6 +265,7 @@ defmodule GuardedStruct.Transformers.Codegen do
       def __guarded_information__, do: __information__()
       def __guarded_fields__, do: __fields__()
       def __guarded_field_meta__(_), do: nil
+      def __guarded_atom_lookup__, do: %{}
 
       @__guarded_has_validator__ Module.defines?(__MODULE__, {:validator, 2}, :def)
       def __guarded_has_validator__, do: @__guarded_has_validator__
@@ -341,6 +346,25 @@ defmodule GuardedStruct.Transformers.Codegen do
   defp entity_name(%Field{name: n}), do: n
   defp entity_name(%SubField{name: n}), do: n
   defp entity_name(other), do: Map.get(other, :name)
+
+  defp atom_lookup_for(keys) when is_list(keys) do
+    for k <- keys, is_atom(k), into: %{}, do: {Atom.to_string(k), k}
+  end
+
+  @doc """
+  Inject `:child_module` into every `:sub_field` entry of the fields list.
+  Called at parent module compile time so the value is
+  `Module.concat(parent, ChildPart)` baked in — runtime never recomputes it.
+  """
+  def bake_child_modules(fields, parent_module) when is_list(fields) do
+    Enum.map(fields, fn
+      %{kind: :sub_field, name: name} = meta ->
+        Map.put(meta, :child_module, Module.concat(parent_module, atom_to_module(name)))
+
+      meta ->
+        meta
+    end)
+  end
 
   defp build_struct_pieces(entities, block_enforce) do
     {virtual_entities, struct_entities} =

--- a/lib/guarded_struct/transformers/generate_ash_validator.ex
+++ b/lib/guarded_struct/transformers/generate_ash_validator.ex
@@ -68,11 +68,6 @@ defmodule GuardedStruct.Transformers.GenerateAshValidator do
       |> MapSet.new()
       |> Macro.escape()
 
-    field_meta_map =
-      fields_runtime
-      |> Map.new(fn m -> {m.name, m} end)
-      |> Macro.escape()
-
     body =
       quote do
         if Module.defines?(__MODULE__, {:__guarded_information__, 0}, :def),
@@ -94,7 +89,13 @@ defmodule GuardedStruct.Transformers.GenerateAshValidator do
           Map.put(unquote(info_map), :module, __MODULE__)
         end
 
-        def __guarded_fields__, do: unquote(Macro.escape(fields_runtime))
+        @__guarded_fields__ GuardedStruct.Transformers.Codegen.bake_child_modules(
+                              unquote(Macro.escape(fields_runtime)),
+                              __MODULE__
+                            )
+        def __guarded_fields__, do: @__guarded_fields__
+
+        def __guarded_atom_lookup__, do: unquote(Macro.escape(atom_lookup_for_ash(keys)))
 
         @doc """
         Compile-time-baked `MapSet` of every field name owned by the
@@ -104,11 +105,13 @@ defmodule GuardedStruct.Transformers.GenerateAshValidator do
         """
         def __guarded_field_name_set__, do: unquote(field_name_set)
 
+        @__guarded_field_meta_map__ Map.new(@__guarded_fields__, fn m -> {m.name, m} end)
+
         @doc """
         O(1) lookup of a field's compile-time metadata by name. Returns
         `nil` for unknown fields.
         """
-        def __guarded_field_meta__(name), do: Map.get(unquote(field_meta_map), name)
+        def __guarded_field_meta__(name), do: Map.get(@__guarded_field_meta_map__, name)
 
         def __field_meta__(name), do: __guarded_field_meta__(name)
 
@@ -140,5 +143,9 @@ defmodule GuardedStruct.Transformers.GenerateAshValidator do
       end
 
     {:ok, Transformer.eval(dsl_state, [], body)}
+  end
+
+  defp atom_lookup_for_ash(keys) when is_list(keys) do
+    for k <- keys, is_atom(k), into: %{}, do: {Atom.to_string(k), k}
   end
 end

--- a/lib/messages.ex
+++ b/lib/messages.ex
@@ -90,6 +90,12 @@ defmodule GuardedStruct.Messages do
   @callback convert_enum_output(any()) :: message()
   @callback equal(any()) :: message()
   @callback record(any()) :: message()
+  @callback slug(any()) :: message()
+  @callback hostname(any()) :: message()
+  @callback port_number(any()) :: message()
+  @callback hex_color(any()) :: message()
+  @callback semver(any()) :: message()
+  @callback each(any()) :: message()
 
   @optional_callbacks required_fields: 0,
                       authorized_fields: 0,
@@ -152,7 +158,13 @@ defmodule GuardedStruct.Messages do
                       is_type: 1,
                       convert_enum_output: 1,
                       equal: 1,
-                      record: 1
+                      record: 1,
+                      slug: 1,
+                      hostname: 1,
+                      port_number: 1,
+                      hex_color: 1,
+                      semver: 1,
+                      each: 1
 
   @doc false
   # Get idea from https://github.com/pow-auth/pow/blob/main/lib/pow/phoenix/messages.ex
@@ -223,6 +235,12 @@ defmodule GuardedStruct.Messages do
       def convert_enum_output(field), do: unquote(__MODULE__).convert_enum_output(field)
       def equal(field), do: unquote(__MODULE__).equal(field)
       def record(field), do: unquote(__MODULE__).record(field)
+      def slug(field), do: unquote(__MODULE__).slug(field)
+      def hostname(field), do: unquote(__MODULE__).hostname(field)
+      def port_number(field), do: unquote(__MODULE__).port_number(field)
+      def hex_color(field), do: unquote(__MODULE__).hex_color(field)
+      def semver(field), do: unquote(__MODULE__).semver(field)
+      def each(field), do: unquote(__MODULE__).each(field)
 
       defoverridable unquote(__MODULE__)
     end
@@ -394,6 +412,21 @@ defmodule GuardedStruct.Messages do
   def record(field) do
     "The #{field} field is not a valid Erlang record (a tagged tuple)."
   end
+
+  def slug(field), do: "Invalid slug format in the #{field} field"
+
+  def hostname(field), do: "Invalid hostname format in the #{field} field"
+
+  def port_number(field),
+    do: "The #{field} field must be a valid TCP/UDP port number between 1 and 65535"
+
+  def hex_color(field),
+    do: "Invalid hex color format in the #{field} field (expected #RRGGBB or #RGB)"
+
+  def semver(field),
+    do: "Invalid semantic version format in the #{field} field (expected MAJOR.MINOR.PATCH)"
+
+  def each(field), do: "One or more items in the #{field} field failed validation"
 
   # Helpers
   def translated_message(fn_atom), do: apply(@message_backend, fn_atom, [])

--- a/lib/messages.ex
+++ b/lib/messages.ex
@@ -429,7 +429,97 @@ defmodule GuardedStruct.Messages do
   def each(field), do: "One or more items in the #{field} field failed validation"
 
   # Helpers
-  def translated_message(fn_atom), do: apply(@message_backend, fn_atom, [])
+  #
+  # Per-key direct-call clauses are generated from the callback list so the
+  # hot path never hits apply/3. Unknown keys fall through to the apply
+  # fallbacks at the bottom (defensive — keeps the public API unchanged).
+  @zero_arity_messages [
+    :required_fields,
+    :authorized_fields,
+    :message_exception,
+    :builder,
+    :register_struct,
+    :list_builder,
+    :list_builder_field_exception,
+    :list_builder_type
+  ]
 
-  def translated_message(fn_atom, options), do: apply(@message_backend, fn_atom, [options])
+  @one_arity_messages [
+    :message_exception,
+    :field,
+    :field_type,
+    :check_dependent_keys,
+    :domain_field_status,
+    :force_domain_field_status,
+    :not_empty_binary,
+    :not_empty_list,
+    :not_empty_map,
+    :not_empty,
+    :not_flatten_empty,
+    :not_flatten_empty_item,
+    :queue,
+    :max_len_binary,
+    :max_len_integer,
+    :max_len_range,
+    :max_len_list,
+    :max_len,
+    :min_len_binary,
+    :min_len_integer,
+    :min_len_range,
+    :min_len_list,
+    :min_len,
+    :url_scheme,
+    :url_host,
+    :url_gethostbyname,
+    :url,
+    :tell,
+    :email,
+    :email_r,
+    :location,
+    :string_boolean,
+    :datetime,
+    :range,
+    :date_binary,
+    :regex,
+    :ipv4,
+    :not_empty_string,
+    :uuid,
+    :username,
+    :full_name,
+    :enum,
+    :custom,
+    :either,
+    :string_float,
+    :string_integer,
+    :some_string_float,
+    :some_string_integer,
+    :validate_unexpected,
+    :location_url,
+    :is_type,
+    :convert_enum_output,
+    :equal,
+    :record,
+    :slug,
+    :hostname,
+    :port_number,
+    :hex_color,
+    :semver,
+    :each
+  ]
+
+  for fun <- @zero_arity_messages do
+    def translated_message(unquote(fun)),
+      do: unquote(@message_backend).unquote(fun)()
+  end
+
+  for fun <- @one_arity_messages do
+    def translated_message(unquote(fun), options),
+      do: unquote(@message_backend).unquote(fun)(options)
+  end
+
+  def translated_message(fn_atom) when is_atom(fn_atom),
+    do: apply(@message_backend, fn_atom, [])
+
+  def translated_message(fn_atom, options) when is_atom(fn_atom),
+    do: apply(@message_backend, fn_atom, [options])
 end

--- a/test/combinator_nesting_test.exs
+++ b/test/combinator_nesting_test.exs
@@ -1,0 +1,237 @@
+defmodule GuardedStructTest.CombinatorNestingTest do
+  use ExUnit.Case, async: true
+
+  alias GuardedStruct.Derive.{OpParamValidator, ValidationDerive, SanitizerDerive}
+
+  # ──────────────────────────────────────────────────────────────────
+  # Runtime — validate side, nested combinators
+  # Pattern checked at each depth: an inner op that ACCEPTS a sample
+  # input returns the input; one that REJECTS produces an :error tuple.
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "validate runtime — 2-level nests" do
+    test "each[either]: every element matches one of N types" do
+      op = %{each: [%{either: [:string, :integer]}]}
+      assert ["a", 2, "c"] == ValidationDerive.validate(op, ["a", 2, "c"], :xs)
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, ["a", 2, :bad_atom], :xs)
+    end
+
+    test "each[optional]: every element may be nil" do
+      op = %{each: [%{optional: [:string]}]}
+      assert ["a", nil, "c"] == ValidationDerive.validate(op, ["a", nil, "c"], :xs)
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, ["a", 42, nil], :xs)
+    end
+
+    test "optional[either]: nil or one of N" do
+      op = %{optional: [%{either: [:string, :integer]}]}
+      assert nil == ValidationDerive.validate(op, nil, :x)
+      assert "ok" == ValidationDerive.validate(op, "ok", :x)
+      assert 7 == ValidationDerive.validate(op, 7, :x)
+      assert {:error, _, :either, _} = ValidationDerive.validate(op, %{}, :x)
+    end
+
+    test "either[each]: either-a-list-of-strings or an integer" do
+      op = %{either: [%{each: [:string]}, :integer]}
+      assert ["a", "b"] == ValidationDerive.validate(op, ["a", "b"], :x)
+      assert 5 == ValidationDerive.validate(op, 5, :x)
+      assert {:error, _, :either, _} = ValidationDerive.validate(op, [1, 2], :x)
+    end
+  end
+
+  describe "validate runtime — 3-level nests" do
+    test "each[optional[either]]: list of (nil-or-one-of)" do
+      op = %{each: [%{optional: [%{either: [:string, :integer]}]}]}
+      assert ["a", nil, 2, "c"] == ValidationDerive.validate(op, ["a", nil, 2, "c"], :xs)
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, ["a", :bad], :xs)
+    end
+
+    test "optional[each[either]]: nil-or-(list-of-one-of)" do
+      op = %{optional: [%{each: [%{either: [:string, :integer]}]}]}
+      assert nil == ValidationDerive.validate(op, nil, :x)
+      assert ["a", 2] == ValidationDerive.validate(op, ["a", 2], :x)
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, ["a", :bad], :x)
+    end
+
+    test "either[each[optional]]: int OR list-of-(nil-or-string)" do
+      op = %{either: [:integer, %{each: [%{optional: [:string]}]}]}
+      assert 5 == ValidationDerive.validate(op, 5, :x)
+      assert ["a", nil, "c"] == ValidationDerive.validate(op, ["a", nil, "c"], :x)
+      assert {:error, _, :either, _} = ValidationDerive.validate(op, [1, 2], :x)
+    end
+  end
+
+  describe "validate runtime — 5-level nests" do
+    # each[each[optional[either[each]]]]: matrix of (nil-or-list-of-string-or-int)
+    test "matrix-of-cells where each cell is nil OR a list of strings/integers" do
+      op = %{
+        each: [
+          %{
+            each: [
+              %{
+                optional: [
+                  %{either: [%{each: [:string]}, %{each: [:integer]}]}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      good = [
+        [["a", "b"], nil, [1, 2]],
+        [nil, ["x"]]
+      ]
+
+      assert good == ValidationDerive.validate(op, good, :grid)
+
+      # Cell contains mixed types -> each-of-strings fails AND each-of-integers fails -> either fails.
+      bad = [[["a", 1], nil]]
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, bad, :grid)
+    end
+  end
+
+  describe "validate runtime — 7-level nests" do
+    # each → optional → either → each → optional → either → string
+    # i.e. list of (nil-or-(list-or-X)) where the leaf is nil-or-(string-or-integer)
+    test "depth-7 alternation of each/optional/either bottoms out at string|integer" do
+      op = %{
+        each: [
+          %{
+            optional: [
+              %{
+                either: [
+                  %{
+                    each: [
+                      %{
+                        optional: [
+                          %{either: [:string, :integer]}
+                        ]
+                      }
+                    ]
+                  },
+                  :string
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      good = [
+        nil,
+        "leaf-string-via-either-second-arm",
+        ["x", nil, 2],
+        [nil, nil]
+      ]
+
+      assert good == ValidationDerive.validate(op, good, :deep)
+
+      # An inner list that contains a bad atom: every either arm fails.
+      bad = [["ok", :nope]]
+      assert {:error, _, :each, _} = ValidationDerive.validate(op, bad, :deep)
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # Runtime — sanitize side, nested :each
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "sanitize runtime — nested each" do
+    test "each[each[trim, downcase]]: nested-list cell cleanup" do
+      op = %{each: [%{each: [:trim, :downcase]}]}
+      input = [["  A  ", "  B  "], ["  C  "]]
+      assert [["a", "b"], ["c"]] == SanitizerDerive.sanitize(input, op)
+    end
+
+    test "each[each[each[trim]]]: 3-deep trim" do
+      op = %{each: [%{each: [%{each: [:trim]}]}]}
+      input = [[["  hi  "], ["  there  "]], [["  ok  "]]]
+      assert [[["hi"], ["there"]], [["ok"]]] == SanitizerDerive.sanitize(input, op)
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # Compile-time — OpParamValidator walks combinator inners recursively
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "OpParamValidator — nested combinator inner ops are checked recursively" do
+    test "3-deep all-valid passes" do
+      ops = %{validate: [%{each: [%{optional: [%{either: [:string, :integer]}]}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "5-deep all-valid passes" do
+      ops = %{
+        validate: [
+          %{
+            each: [
+              %{
+                optional: [
+                  %{either: [%{each: [:string]}, %{each: [:integer]}]}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "7-deep all-valid passes" do
+      ops = %{
+        validate: [
+          %{
+            each: [
+              %{
+                optional: [
+                  %{
+                    either: [
+                      %{each: [%{optional: [%{either: [:string, :integer]}]}]},
+                      :string
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "bad param shape deep inside an each→optional→either chain raises with the bad op name" do
+      ops = %{
+        validate: [
+          %{each: [%{optional: [%{either: [:string, {:max_len, "bad"}]}]}]}
+        ]
+      }
+
+      assert_raise Spark.Error.DslError, ~r/invalid parameter for `max_len`/, fn ->
+        OpParamValidator.validate!(ops, :name, FakeMod)
+      end
+    end
+
+    test "unknown op deep inside an each→optional chain raises with its name" do
+      ops = %{validate: [%{each: [%{optional: [:strng]}]}]}
+
+      assert_raise Spark.Error.DslError, ~r/unknown validate op :strng/, fn ->
+        OpParamValidator.validate!(ops, :name, FakeMod)
+      end
+    end
+
+    test "sanitize side: 3-deep each-each-each passes" do
+      ops = %{sanitize: [%{each: [%{each: [%{each: [:trim, :downcase]}]}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "sanitize side: bad inner deep inside each chain raises" do
+      ops = %{sanitize: [%{each: [%{each: [:not_a_sanitize_op]}]}]}
+
+      assert_raise Spark.Error.DslError, ~r/unknown sanitize op :not_a_sanitize_op/, fn ->
+        OpParamValidator.validate!(ops, :name, FakeMod)
+      end
+    end
+  end
+end

--- a/test/combinator_nesting_test.exs
+++ b/test/combinator_nesting_test.exs
@@ -3,6 +3,136 @@ defmodule GuardedStructTest.CombinatorNestingTest do
 
   alias GuardedStruct.Derive.{OpParamValidator, ValidationDerive, SanitizerDerive}
 
+  # ────────────────────────────────────────────────────────────────
+  # Fixtures — exercise the FULL macro pipeline: derive-string parser
+  # → OpEvaluator → OpParamValidator → ValidationDerive/SanitizerDerive.
+  # If anything in that chain mishandles a combinator, builder/1 fails.
+  # ────────────────────────────────────────────────────────────────
+
+  defmodule EitherFlat do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:val, any(), derives: "validate(either=[string, integer])")
+    end
+  end
+
+  defmodule EachFlat do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:items, list(), derives: "validate(each=[string])")
+    end
+  end
+
+  defmodule OptionalFlat do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:nick, any(), derives: "validate(optional=[string, max_len=5])")
+    end
+  end
+
+  defmodule OptionalBareAtom do
+    # The bare-atom form is the one that USED to allocate a binary inner
+    # op and pay String.to_existing_atom + rescue per call. Now it's
+    # parsed to {:optional, [:string]} at compile time.
+    use GuardedStruct
+
+    guardedstruct do
+      field(:nick, any(), derives: "validate(optional=string)")
+    end
+  end
+
+  defmodule SanitizeEach do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:tags, list(),
+        derives: "sanitize(each=[trim, downcase], uniq) validate(each=[string])"
+      )
+    end
+  end
+
+  defmodule EachEither do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:cells, list(), derives: "validate(each=[either=[string, integer]])")
+    end
+  end
+
+  defmodule OptionalEach do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:maybe_tags, any(), derives: "validate(optional=[each=[string]])")
+    end
+  end
+
+  defmodule EitherEach do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:int_or_list, any(),
+        derives: "validate(either=[integer, each=[string]])"
+      )
+    end
+  end
+
+  defmodule DeepNest do
+    # 5-deep through the macro pipeline:
+    #   each → optional → either → each → string
+    use GuardedStruct
+
+    guardedstruct do
+      field(:grid, list(),
+        derives:
+          "validate(each=[optional=[either=[each=[string], each=[integer]]]])"
+      )
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────
+  # Macro pipeline fixtures at depth 8, 10, 12 — hand-written so the
+  # parser actually sees a real long string (not something a runtime
+  # helper assembled). Each level cycles through each→optional→either,
+  # leaf is :string.
+  # ────────────────────────────────────────────────────────────────
+
+  defmodule Depth8 do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:x, any(),
+        derives:
+          "validate(each=[optional=[either=[each=[optional=[either=[each=[optional=[string]]]]]]]])"
+      )
+    end
+  end
+
+  defmodule Depth10 do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:x, any(),
+        derives:
+          "validate(each=[optional=[either=[each=[optional=[either=[each=[optional=[either=[each=[string]]]]]]]]]])"
+      )
+    end
+  end
+
+  defmodule Depth12 do
+    use GuardedStruct
+
+    guardedstruct do
+      field(:x, any(),
+        derives:
+          "validate(each=[optional=[either=[each=[optional=[either=[each=[optional=[either=[each=[optional=[either=[string]]]]]]]]]]]])"
+      )
+    end
+  end
+
   # ──────────────────────────────────────────────────────────────────
   # Runtime — validate side, nested combinators
   # Pattern checked at each depth: an inner op that ACCEPTS a sample
@@ -232,6 +362,354 @@ defmodule GuardedStructTest.CombinatorNestingTest do
       assert_raise Spark.Error.DslError, ~r/unknown sanitize op :not_a_sanitize_op/, fn ->
         OpParamValidator.validate!(ops, :name, FakeMod)
       end
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # End-to-end through Module.builder/1 — exercises the full pipeline
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "either= through builder/1" do
+    test "string passes" do
+      assert {:ok, %EitherFlat{val: "ok"}} = EitherFlat.builder(%{val: "ok"})
+    end
+
+    test "integer passes" do
+      assert {:ok, %EitherFlat{val: 7}} = EitherFlat.builder(%{val: 7})
+    end
+
+    test "neither matches → error" do
+      assert {:error, errors} = EitherFlat.builder(%{val: :atom_bad})
+      assert Enum.any?(errors, &(&1.action == :either))
+    end
+  end
+
+  describe "each= through builder/1" do
+    test "all-strings list passes" do
+      assert {:ok, %EachFlat{items: ["a", "b"]}} = EachFlat.builder(%{items: ["a", "b"]})
+    end
+
+    test "one bad element → error with index info" do
+      assert {:error, errors} = EachFlat.builder(%{items: ["a", 2, "c"]})
+      err = Enum.find(errors, &(&1.action == :each))
+      assert err
+      assert err.message =~ "failed indices"
+    end
+  end
+
+  describe "optional= through builder/1 (bracket form)" do
+    test "nil passes" do
+      assert {:ok, %OptionalFlat{nick: nil}} = OptionalFlat.builder(%{nick: nil})
+    end
+
+    test "short string passes" do
+      assert {:ok, %OptionalFlat{nick: "ab"}} = OptionalFlat.builder(%{nick: "ab"})
+    end
+
+    test "too-long string fails the inner max_len" do
+      assert {:error, _errors} = OptionalFlat.builder(%{nick: "abcdef"})
+    end
+  end
+
+  describe "optional=bare-atom through builder/1 (the kill-the-rescue path)" do
+    test "nil passes (optional)" do
+      assert {:ok, %OptionalBareAtom{nick: nil}} = OptionalBareAtom.builder(%{nick: nil})
+    end
+
+    test "string passes" do
+      assert {:ok, %OptionalBareAtom{nick: "ok"}} = OptionalBareAtom.builder(%{nick: "ok"})
+    end
+
+    test "non-string non-nil fails" do
+      assert {:error, _errors} = OptionalBareAtom.builder(%{nick: 42})
+    end
+  end
+
+  describe "sanitize each= through builder/1" do
+    test "every element trimmed + downcased; duplicates dropped" do
+      assert {:ok, %SanitizeEach{tags: ["foo", "bar"]}} =
+               SanitizeEach.builder(%{tags: ["  Foo  ", "  BAR  ", "foo"]})
+    end
+  end
+
+  describe "nested combinators through builder/1" do
+    test "each[either]: list of (string|integer)" do
+      assert {:ok, %EachEither{cells: ["a", 2, "c"]}} =
+               EachEither.builder(%{cells: ["a", 2, "c"]})
+
+      assert {:error, errors} = EachEither.builder(%{cells: ["a", 2, :atom_bad]})
+      assert Enum.any?(errors, &(&1.action == :each))
+    end
+
+    test "optional[each]: nil-or-(list-of-strings)" do
+      assert {:ok, %OptionalEach{maybe_tags: nil}} = OptionalEach.builder(%{maybe_tags: nil})
+
+      assert {:ok, %OptionalEach{maybe_tags: ["a", "b"]}} =
+               OptionalEach.builder(%{maybe_tags: ["a", "b"]})
+
+      assert {:error, _} = OptionalEach.builder(%{maybe_tags: ["a", 2]})
+    end
+
+    test "either[each]: integer-or-(list-of-strings)" do
+      assert {:ok, %EitherEach{int_or_list: 5}} = EitherEach.builder(%{int_or_list: 5})
+
+      assert {:ok, %EitherEach{int_or_list: ["a", "b"]}} =
+               EitherEach.builder(%{int_or_list: ["a", "b"]})
+
+      assert {:error, _} = EitherEach.builder(%{int_or_list: [1, 2]})
+    end
+
+    test "5-deep nest through derive string: each→optional→either→each→leaf" do
+      # Each cell: nil OR (list-of-strings OR list-of-integers)
+      good_grid = [["a", "b"], nil, [1, 2], nil]
+      assert {:ok, %DeepNest{grid: ^good_grid}} = DeepNest.builder(%{grid: good_grid})
+
+      # Mixed types inside an inner list → both either arms fail → :each error bubbles up
+      bad_grid = [["a", 1]]
+      assert {:error, errors} = DeepNest.builder(%{grid: bad_grid})
+      assert Enum.any?(errors, &(&1.action == :each))
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # Truly-deep nesting — cycle each → optional → either at every level,
+  # leaf is :string. Tests at depths 8, 10, 12, 15 confirm the
+  # dispatcher has NO depth limit and the OpParamValidator descends
+  # the whole chain at compile time.
+  # ──────────────────────────────────────────────────────────────────
+
+  # Build a depth-N nested op cycling each→optional→either.
+  defp deep_op(0, leaf), do: leaf
+  defp deep_op(n, leaf) when n > 0, do: wrap(n, deep_op(n - 1, leaf))
+
+  defp wrap(n, inner) do
+    case rem(n, 3) do
+      1 -> %{each: [inner]}
+      2 -> %{optional: [inner]}
+      0 -> %{either: [inner]}
+    end
+  end
+
+  # Build a value that satisfies a depth-N op shape. For each layer,
+  # wrap in a 1-element list (for :each) or pass through (for :optional /
+  # :either with a single inner).
+  defp deep_value(0, leaf_value), do: leaf_value
+  defp deep_value(n, leaf_value) when n > 0, do: wrap_value(n, deep_value(n - 1, leaf_value))
+
+  defp wrap_value(n, inner) do
+    case rem(n, 3) do
+      1 -> [inner]
+      2 -> inner
+      0 -> inner
+    end
+  end
+
+  describe "DIRECT API — really deep nesting" do
+    for depth <- [8, 10, 12, 15] do
+      @depth depth
+      test "depth #{@depth}: roundtrip with valid leaf" do
+        op = deep_op(@depth, :string)
+        value = deep_value(@depth, "leaf")
+        assert ^value = ValidationDerive.validate(op, value, :deep)
+      end
+
+      test "depth #{@depth}: failing leaf bubbles up as :each error" do
+        op = deep_op(@depth, :string)
+        # Replace the leaf with an atom (fails :string validator)
+        value = deep_value(@depth, :wrong_type)
+
+        result = ValidationDerive.validate(op, value, :deep)
+        assert is_tuple(result), "expected error tuple at depth #{@depth}, got: #{inspect(result)}"
+        # Outermost is :each at depth 1, 4, 7, 10, 13... (rem == 1)
+        # So depths 8, 10 outermost is :each or other — assert error of SOME action
+        action = elem(result, 2)
+        assert action in [:each, :either, :optional, :string, :type]
+      end
+
+      test "depth #{@depth}: OpParamValidator passes the all-valid chain at compile time" do
+        ops = %{validate: [deep_op(@depth, :string)]}
+        assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+      end
+
+      test "depth #{@depth}: OpParamValidator catches an unknown op buried at the leaf" do
+        # Replace leaf :string with an unregistered atom
+        ops = %{validate: [deep_op(@depth, :no_such_validator)]}
+
+        assert_raise Spark.Error.DslError,
+                     ~r/unknown validate op :no_such_validator/,
+                     fn -> OpParamValidator.validate!(ops, :name, FakeMod) end
+      end
+    end
+  end
+
+  describe "MACRO PIPELINE — really deep nesting via derive string" do
+    test "depth 8: builder roundtrips a value that drills all the way down" do
+      # Each → optional → either → each → optional → either → each → optional → :string
+      # The optional/either-with-single-arg arms degenerate to identity for the value,
+      # so the value path needs :each wrappers (4 of them: at depths 8, 5, 2... wait
+      # only :each wraps in a list). Depth 8 with cycle each/opt/either/each/opt/either/each/opt:
+      # eaches at outer indices 8, 5, 2 → 3 list wrappings. Leaf = "ok".
+      value = [[[ "ok" ]]]
+      assert {:ok, %Depth8{x: ^value}} = Depth8.builder(%{x: value})
+
+      # Nil at any 'optional' layer also passes.
+      assert {:ok, %Depth8{x: [[nil]]}} = Depth8.builder(%{x: [[nil]]})
+      assert {:ok, %Depth8{x: [nil]}} = Depth8.builder(%{x: [nil]})
+
+      # Bad leaf bubbles up.
+      assert {:error, errors} = Depth8.builder(%{x: [[[:not_string]]]})
+      assert Enum.any?(errors, &(&1.action == :each))
+    end
+
+    test "depth 10: builder roundtrips a value that drills all the way down" do
+      # Cycle: each, opt, either, each, opt, either, each, opt, either, each
+      # → :each at outer-indices 10, 7, 4, 1 → 4 list wrappings around the leaf
+      value = [[[["ok"]]]]
+      assert {:ok, %Depth10{x: ^value}} = Depth10.builder(%{x: value})
+
+      # Bad leaf bubbles up
+      assert {:error, errors} = Depth10.builder(%{x: [[[[:not_string]]]]})
+      assert Enum.any?(errors, &(&1.action == :each))
+    end
+
+    test "depth 12: builder roundtrips a value that drills all the way down" do
+      # Cycle: e,o,ei,e,o,ei,e,o,ei,e,o,ei
+      # :each at depths 12, 9, 6, 3 → 4 list wrappings; leaf is the innermost value
+      value = [[[["ok"]]]]
+      assert {:ok, %Depth12{x: ^value}} = Depth12.builder(%{x: value})
+
+      # Bad leaf
+      assert {:error, errors} = Depth12.builder(%{x: [[[[:not_string]]]]})
+      assert Enum.any?(errors, &(&1.action == :each))
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # EXPLICIT expected-value tables — prove the logic by literal.
+  # Reader can verify by eye that the op shape, the input, and the
+  # asserted output all line up with the documented semantics.
+  # ──────────────────────────────────────────────────────────────────
+
+  describe "expected-value confirmation (op, input, output are all literal)" do
+    test "depth 3 — each[either[optional[string]]]: ANY element nil or a string" do
+      op = %{each: [%{either: [%{optional: [:string]}]}]}
+
+      assert ["a", nil, "c"] == ValidationDerive.validate(op, ["a", nil, "c"], :xs)
+      assert [] == ValidationDerive.validate(op, [], :xs)
+      assert [nil, nil] == ValidationDerive.validate(op, [nil, nil], :xs)
+
+      # One non-string non-nil element fails the inner string check; either has
+      # only one arm so it surfaces as :either; the outer each surfaces as :each.
+      result = ValidationDerive.validate(op, ["a", 2, "c"], :xs)
+      assert {:error, :xs, :each, msg} = result
+      assert msg =~ "failed indices"
+    end
+
+    test "depth 5 — each[optional[either[each[string], each[integer]]]]" do
+      op = %{
+        each: [
+          %{
+            optional: [
+              %{either: [%{each: [:string]}, %{each: [:integer]}]}
+            ]
+          }
+        ]
+      }
+
+      # Each cell is nil OR (list-of-strings OR list-of-integers)
+      input = [["a", "b"], nil, [1, 2]]
+      assert ^input = ValidationDerive.validate(op, input, :grid)
+
+      # Mixed strings-and-ints in ONE cell → both either arms fail
+      bad = [["a", 1]]
+      assert {:error, :grid, :each, _} = ValidationDerive.validate(op, bad, :grid)
+    end
+
+    test "nil at intermediate optional layer short-circuits (proves optional is real, not passthrough)" do
+      # opt[each[optional[string]]]:  outer-opt allows nil at the very top;
+      # otherwise each elem may itself be nil.
+      op = %{optional: [%{each: [%{optional: [:string]}]}]}
+
+      assert nil == ValidationDerive.validate(op, nil, :x)
+      assert ["a", nil, "b"] == ValidationDerive.validate(op, ["a", nil, "b"], :x)
+      assert [] == ValidationDerive.validate(op, [], :x)
+
+      assert {:error, :x, :each, _} = ValidationDerive.validate(op, ["a", 2], :x)
+    end
+
+    test "either with two arms picks whichever passes — value unchanged either way" do
+      op = %{either: [%{each: [:string]}, :integer]}
+
+      assert ["a", "b"] == ValidationDerive.validate(op, ["a", "b"], :x)
+      assert 5 == ValidationDerive.validate(op, 5, :x)
+      # Both arms fail: list-of-strings fails (1 not a string) AND integer fails (list not int)
+      assert {:error, :x, :either, _} = ValidationDerive.validate(op, [1], :x)
+    end
+
+    test "depth 7 explicit — confirm value flows untransformed" do
+      op = %{
+        each: [
+          %{
+            optional: [
+              %{
+                either: [
+                  %{each: [%{optional: [%{either: [:string, :integer]}]}]},
+                  :string
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      input = [
+        nil,
+        "second-arm-leaf-string",
+        ["x", nil, 2],
+        [nil]
+      ]
+
+      # The value must come back BIT-FOR-BIT identical — no list wrapping, no atom coercion.
+      assert ^input = ValidationDerive.validate(op, input, :deep)
+      assert input == ValidationDerive.validate(op, input, :deep)
+    end
+
+    test "depth 8 explicit roundtrip: value structure is documented literally" do
+      # op cycle (innermost→outermost): :string, :each, :optional, :either,
+      # :each, :optional, :either, :each, :optional
+      op = deep_op(8, :string)
+
+      # Document the op so a reviewer can see it:
+      assert op == %{
+               optional: [
+                 %{
+                   each: [
+                     %{
+                       either: [
+                         %{
+                           optional: [
+                             %{each: [%{either: [%{optional: [%{each: [:string]}]}]}]}
+                           ]
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               ]
+             }
+
+      # eaches sit at n=7, n=4, n=1 → 3 list wrappings around the leaf
+      value = [[["leaf"]]]
+      assert value == deep_value(8, "leaf")
+      assert ^value = ValidationDerive.validate(op, value, :deep)
+    end
+
+    test "depth 15 explicit roundtrip: 5 list wrappings around the leaf" do
+      # eaches at n=13, n=10, n=7, n=4, n=1 → 5 list wrappings
+      op = deep_op(15, :string)
+      value = [[[[["leaf"]]]]]
+      assert value == deep_value(15, "leaf")
+      assert ^value = ValidationDerive.validate(op, value, :deep)
     end
   end
 end

--- a/test/convert_to_atom_map_test.exs
+++ b/test/convert_to_atom_map_test.exs
@@ -1,0 +1,95 @@
+defmodule GuardedStructTest.ConvertToAtomMapTest do
+  use ExUnit.Case, async: true
+
+  alias GuardedStruct.Derive.Parser
+
+  describe "convert_to_atom_map/2 — no lookup (legacy 2-arity)" do
+    test "converts known atom-name string keys" do
+      assert %{name: "Alice", age: 30} =
+               Parser.convert_to_atom_map(%{"name" => "Alice", "age" => 30})
+    end
+
+    test "leaves unknown string keys as strings (atom-DoS safety)" do
+      unique = "_unique_garbage_key_for_test_#{System.unique_integer([:positive])}_"
+      result = Parser.convert_to_atom_map(%{unique => "value"})
+      assert %{^unique => "value"} = result
+    end
+
+    test "recurses into nested maps" do
+      assert %{name: "Alice", profile: %{age: 30}} =
+               Parser.convert_to_atom_map(%{"name" => "Alice", "profile" => %{"age" => 30}})
+    end
+
+    test "honors passthrough_keys — values stay untouched at any depth" do
+      assert %{tags: %{"deep" => %{"nested" => 1}}} =
+               Parser.convert_to_atom_map(
+                 %{"tags" => %{"deep" => %{"nested" => 1}}},
+                 [:tags]
+               )
+    end
+
+    test "unwraps {:ok, map} input" do
+      assert %{name: "Alice"} = Parser.convert_to_atom_map({:ok, %{"name" => "Alice"}})
+    end
+
+    test "passes {:error, _, _} input through unchanged" do
+      err = {:error, :reason, "details"}
+      assert ^err = Parser.convert_to_atom_map(err)
+    end
+
+    test "converts a struct by taking its map representation" do
+      uri = URI.parse("https://example.com")
+      result = Parser.convert_to_atom_map(uri)
+      assert is_map(result)
+      refute Map.has_key?(result, :__struct__)
+      assert result.host == "example.com"
+    end
+  end
+
+  describe "convert_to_atom_map/3 — with atom_lookup (the #6 compile-time fast path)" do
+    test "uses lookup hit and bypasses String.to_existing_atom" do
+      lookup = %{"name" => :name, "age" => :age}
+      assert %{name: "Alice", age: 30} =
+               Parser.convert_to_atom_map(%{"name" => "Alice", "age" => 30}, [], lookup)
+    end
+
+    test "lookup miss falls back to safe rescue (unknown stays string)" do
+      lookup = %{"name" => :name}
+      unique = "_garbage_lookup_miss_#{System.unique_integer([:positive])}_"
+      result = Parser.convert_to_atom_map(%{"name" => "Alice", unique => "x"}, [], lookup)
+      assert result[:name] == "Alice"
+      assert result[unique] == "x"
+    end
+
+    test "empty lookup map still works (degrades to rescue path)" do
+      assert %{name: "Alice"} =
+               Parser.convert_to_atom_map(%{"name" => "Alice"}, [], %{})
+    end
+
+    test "nil lookup is equivalent to 2-arity behavior" do
+      base = Parser.convert_to_atom_map(%{"name" => "Alice"})
+      with_nil = Parser.convert_to_atom_map(%{"name" => "Alice"}, [], nil)
+      assert base == with_nil
+    end
+
+    test "passthrough_keys still suppresses recursion when lookup is set" do
+      lookup = %{"tags" => :tags}
+
+      assert %{tags: %{"deep" => 1}} =
+               Parser.convert_to_atom_map(
+                 %{"tags" => %{"deep" => 1}},
+                 [:tags],
+                 lookup
+               )
+    end
+
+    test "lookup matches by exact string — alias mismatches don't apply" do
+      # If a lookup says "Name" -> :name, the key "name" misses the lookup
+      # and falls back to rescue (string preserved if no atom exists).
+      lookup = %{"Name" => :name}
+      unique = "_no_atom_for_this_#{System.unique_integer([:positive])}_"
+      result = Parser.convert_to_atom_map(%{unique => "x"}, [], lookup)
+      assert %{^unique => "x"} = result
+    end
+  end
+end

--- a/test/derive_extension_test.exs
+++ b/test/derive_extension_test.exs
@@ -10,33 +10,33 @@ defmodule GuardedStructTest.DeriveExtensionTest do
   end
 
   test "registered extension exposes its validator/sanitizer names" do
-    assert SlugDerives.__validators__() == [:slug]
+    assert SlugDerives.__validators__() == [:my_slug]
     assert SlugDerives.__sanitizers__() == [:slugify]
     assert SlugDerives.__derive_extension__?()
   end
 
   test "extension validator runs against input" do
-    assert {:ok, %{slug: "valid-slug"}} = WithSlug.builder(%{slug: "valid-slug"})
+    assert {:ok, %{my_slug: "valid-slug"}} = WithSlug.builder(%{my_slug: "valid-slug"})
 
-    assert {:error, [%{field: :slug, action: :slug}]} =
-             WithSlug.builder(%{slug: "Not Valid Slug!"})
+    assert {:error, [%{field: :my_slug, action: :my_slug}]} =
+             WithSlug.builder(%{my_slug: "Not Valid Slug!"})
   end
 
   test "extension sanitizer runs against input" do
-    assert {:ok, %{slug: "hello-world"}} = WithSlugify.builder(%{slug: "Hello World!"})
+    assert {:ok, %{my_slug: "hello-world"}} = WithSlugify.builder(%{my_slug: "Hello World!"})
   end
 
   test "extension dispatch finds the registered op" do
-    assert "abc" = GuardedStruct.Derive.Extension.dispatch_validate(:slug, "abc", :test)
+    assert "abc" = GuardedStruct.Derive.Extension.dispatch_validate(:my_slug, "abc", :test)
 
-    assert {:error, :test, :slug, _} =
-             GuardedStruct.Derive.Extension.dispatch_validate(:slug, "AB!", :test)
+    assert {:error, :test, :my_slug, _} =
+             GuardedStruct.Derive.Extension.dispatch_validate(:my_slug, "AB!", :test)
 
     assert :__not_found__ =
              GuardedStruct.Derive.Extension.dispatch_validate(:nonexistent, "x", :test)
   end
 
   test "all_extension_validators aggregates across registered modules" do
-    assert :slug in MapSet.to_list(GuardedStruct.Derive.Extension.all_extension_validators())
+    assert :my_slug in MapSet.to_list(GuardedStruct.Derive.Extension.all_extension_validators())
   end
 end

--- a/test/derive_extensions_per_module_test.exs
+++ b/test/derive_extensions_per_module_test.exs
@@ -9,7 +9,7 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
     * No opt → falls back to global Application config (legacy behavior)
     * `[]`   → opts OUT entirely (no extensions, global ignored)
     * `[A]`  → REPLACE global with [A]
-    * `[:config, A]` → global ++ [A] (global wins on :slug-style collisions)
+    * `[:config, A]` → global ++ [A] (global wins on :my_slug-style collisions)
     * `[A, :config]` → [A] ++ global (A wins on collisions)
     * `[A, :config, B]` → [A] ++ global ++ [B] (in-position merge)
     * `[:config, :config]` → ArgumentError at compile time
@@ -20,7 +20,7 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
   # async: false — we mutate Application env, which is process-global.
   use ExUnit.Case, async: false
 
-  # Two extension modules with a deliberately overlapping op name `:slug`
+  # Two extension modules with a deliberately overlapping op name `:my_slug`
   # so we can prove who wins on collisions.
 
   defmodule GlobalDerives do
@@ -28,7 +28,7 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
 
     derives do
       # Accepts only "global:..." prefixed slugs
-      validator :slug, fn input ->
+      validator :my_slug, fn input ->
         is_binary(input) and String.starts_with?(input, "global:")
       end
 
@@ -41,8 +41,8 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
     use GuardedStruct.Derive.Extension
 
     derives do
-      # Accepts only "local:..." prefixed slugs (collides with GlobalDerives.:slug)
-      validator :slug, fn input ->
+      # Accepts only "local:..." prefixed slugs (collides with GlobalDerives.:my_slug)
+      validator :my_slug, fn input ->
         is_binary(input) and String.starts_with?(input, "local:")
       end
 
@@ -75,15 +75,15 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
       end
     end
 
-    test "GlobalDerives.:slug active (only 'global:...' accepted)" do
-      assert {:ok, _} = NoOpt.builder(%{slug: "global:hello"})
+    test "GlobalDerives.:my_slug active (only 'global:...' accepted)" do
+      assert {:ok, _} = NoOpt.builder(%{my_slug: "global:hello"})
 
-      assert {:error, errs} = NoOpt.builder(%{slug: "local:hello"})
-      assert Enum.any?(errs, &(&1[:field] == :slug and &1[:action] == :slug))
+      assert {:error, errs} = NoOpt.builder(%{my_slug: "local:hello"})
+      assert Enum.any?(errs, &(&1[:field] == :my_slug and &1[:action] == :my_slug))
     end
 
     test "__guarded_derive_extensions_opt__/0 returns nil (no opt set)" do
@@ -102,7 +102,7 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       end
     end
 
-    test "global is ignored — :slug is no longer known if we tried it" do
+    test "global is ignored — :my_slug is no longer known if we tried it" do
       # Use a built-in op so the field still validates; the point is to
       # confirm that the module's extension list resolves to [].
       assert {:ok, _} = EmptyOpt.builder(%{name: "x"})
@@ -123,15 +123,15 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [LocalDerives]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
       end
     end
 
-    test "LocalDerives.:slug active — only 'local:...' accepted" do
-      assert {:ok, _} = ReplaceOpt.builder(%{slug: "local:hello"})
+    test "LocalDerives.:my_slug active — only 'local:...' accepted" do
+      assert {:ok, _} = ReplaceOpt.builder(%{my_slug: "local:hello"})
 
-      assert {:error, errs} = ReplaceOpt.builder(%{slug: "global:hello"})
-      assert Enum.any?(errs, &(&1[:field] == :slug))
+      assert {:error, errs} = ReplaceOpt.builder(%{my_slug: "global:hello"})
+      assert Enum.any?(errs, &(&1[:field] == :my_slug))
     end
 
     test "global is COMPLETELY ignored — :uuid7 (only in global) becomes unknown" do
@@ -158,21 +158,21 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [:config, LocalDerives]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
         field(:tag, String.t(), derives: "validate(ksuid)")
       end
     end
 
-    test "GLOBAL :slug wins on collision (first in list)" do
-      assert {:ok, _} = ConfigFirst.builder(%{slug: "global:x", tag: "k"})
+    test "GLOBAL :my_slug wins on collision (first in list)" do
+      assert {:ok, _} = ConfigFirst.builder(%{my_slug: "global:x", tag: "k"})
 
-      # LocalDerives'.slug is shadowed → "local:..." rejected
-      assert {:error, errs} = ConfigFirst.builder(%{slug: "local:x", tag: "k"})
-      assert Enum.any?(errs, &(&1[:field] == :slug))
+      # LocalDerives'.my_slug is shadowed → "local:..." rejected
+      assert {:error, errs} = ConfigFirst.builder(%{my_slug: "local:x", tag: "k"})
+      assert Enum.any?(errs, &(&1[:field] == :my_slug))
     end
 
     test "non-colliding local op (:ksuid) is still available" do
-      assert {:ok, _} = ConfigFirst.builder(%{slug: "global:x", tag: "any-ksuid"})
+      assert {:ok, _} = ConfigFirst.builder(%{my_slug: "global:x", tag: "any-ksuid"})
     end
   end
 
@@ -183,20 +183,20 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [LocalDerives, :config]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
         field(:other, String.t(), derives: "validate(uuid7)")
       end
     end
 
-    test "LOCAL :slug wins on collision (first in list)" do
-      assert {:ok, _} = ConfigLast.builder(%{slug: "local:x", other: "x"})
+    test "LOCAL :my_slug wins on collision (first in list)" do
+      assert {:ok, _} = ConfigLast.builder(%{my_slug: "local:x", other: "x"})
 
-      assert {:error, _} = ConfigLast.builder(%{slug: "global:x", other: "x"})
+      assert {:error, _} = ConfigLast.builder(%{my_slug: "global:x", other: "x"})
     end
 
     test "global-only op (:uuid7) still available via fall-through" do
       # uuid7 doesn't exist in LocalDerives — falls through to GlobalDerives
-      assert {:ok, _} = ConfigLast.builder(%{slug: "local:x", other: "anything"})
+      assert {:ok, _} = ConfigLast.builder(%{my_slug: "local:x", other: "anything"})
     end
   end
 
@@ -207,25 +207,25 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [LocalDerives, :config, ExtraDerives]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
         field(:tag, String.t(), derives: "validate(ksuid)")
         field(:tel, String.t(), derives: "validate(phone)")
         field(:id, String.t(), derives: "validate(uuid7)")
       end
     end
 
-    test "LOCAL :slug wins (first in resolved list)" do
+    test "LOCAL :my_slug wins (first in resolved list)" do
       assert {:ok, _} =
-               InPosition.builder(%{slug: "local:x", tag: "k", tel: "p", id: "u"})
+               InPosition.builder(%{my_slug: "local:x", tag: "k", tel: "p", id: "u"})
 
       assert {:error, _} =
-               InPosition.builder(%{slug: "global:x", tag: "k", tel: "p", id: "u"})
+               InPosition.builder(%{my_slug: "global:x", tag: "k", tel: "p", id: "u"})
     end
 
     test "ops from all three sources are available" do
       # :ksuid from LocalDerives, :uuid7 from GlobalDerives, :phone from ExtraDerives
       assert {:ok, _} =
-               InPosition.builder(%{slug: "local:x", tag: "k", tel: "p", id: "u"})
+               InPosition.builder(%{my_slug: "local:x", tag: "k", tel: "p", id: "u"})
     end
   end
 
@@ -328,7 +328,7 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [LocalDerives]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
       end
     end
 
@@ -336,39 +336,39 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
         field(:inner, struct(), struct: UsesLocal)
       end
     end
 
     test "outer module's extensions don't leak into inner builder" do
-      # The outer struct's :slug uses GLOBAL (no opt → global).
-      # The inner struct's :slug uses LOCAL (per-module opt).
+      # The outer struct's :my_slug uses GLOBAL (no opt → global).
+      # The inner struct's :my_slug uses LOCAL (per-module opt).
       # Both must enforce their own rule simultaneously.
       assert {:ok, _} =
                UsesGlobal.builder(%{
-                 slug: "global:outer",
-                 inner: %{slug: "local:inner"}
+                 my_slug: "global:outer",
+                 inner: %{my_slug: "local:inner"}
                })
 
       # Outer accepts "global:..." but inner rejects it (it expects "local:...")
       assert {:error, _} =
                UsesGlobal.builder(%{
-                 slug: "global:outer",
-                 inner: %{slug: "global:outer"}
+                 my_slug: "global:outer",
+                 inner: %{my_slug: "global:outer"}
                })
 
       # Outer rejects "local:..." while inner accepts it.
       assert {:error, _} =
                UsesGlobal.builder(%{
-                 slug: "local:outer",
-                 inner: %{slug: "local:inner"}
+                 my_slug: "local:outer",
+                 inner: %{my_slug: "local:inner"}
                })
     end
 
     test "Process dict is cleaned up after build (no leak between calls)" do
       refute Process.get(:guarded_struct_current_module)
-      {:ok, _} = UsesGlobal.builder(%{slug: "global:x", inner: %{slug: "local:y"}})
+      {:ok, _} = UsesGlobal.builder(%{my_slug: "global:x", inner: %{my_slug: "local:y"}})
       refute Process.get(:guarded_struct_current_module)
     end
   end
@@ -381,18 +381,18 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
 
       guardedstruct do
         sub_field(:nested, struct()) do
-          field(:slug, String.t(), derives: "validate(slug)")
+          field(:my_slug, String.t(), derives: "validate(my_slug)")
         end
       end
     end
 
-    test "field inside a sub_field uses the parent's :slug extension" do
+    test "field inside a sub_field uses the parent's :my_slug extension" do
       # WithSub's parent extension list is [LocalDerives]. The auto-generated
       # WithSub.Nested submodule doesn't have its own use GuardedStruct, so
       # its derive validation should use LocalDerives via the process dict.
-      assert {:ok, _} = WithSub.builder(%{nested: %{slug: "local:hello"}})
+      assert {:ok, _} = WithSub.builder(%{nested: %{my_slug: "local:hello"}})
 
-      assert {:error, _} = WithSub.builder(%{nested: %{slug: "global:hello"}})
+      assert {:error, _} = WithSub.builder(%{nested: %{my_slug: "global:hello"}})
     end
   end
 
@@ -403,24 +403,24 @@ defmodule GuardedStructTest.DeriveExtensionsPerModuleTest do
       use GuardedStruct, derive_extensions: [:config, LocalDerives]
 
       guardedstruct do
-        field(:slug, String.t(), derives: "validate(slug)")
+        field(:my_slug, String.t(), derives: "validate(my_slug)")
       end
     end
 
     test "swapping the global config affects already-compiled modules" do
       # Setup put [GlobalDerives] globally — LazyConfig accepts "global:..."
-      assert {:ok, _} = LazyConfig.builder(%{slug: "global:x"})
+      assert {:ok, _} = LazyConfig.builder(%{my_slug: "global:x"})
 
-      # Now swap the global config to [ExtraDerives] which has no :slug op.
-      # LazyConfig should now ONLY have LocalDerives.slug active.
+      # Now swap the global config to [ExtraDerives] which has no :my_slug op.
+      # LazyConfig should now ONLY have LocalDerives.my_slug active.
       Application.put_env(:guarded_struct, :derive_extensions, [ExtraDerives])
 
       try do
         # "global:..." no longer accepted — GlobalDerives is gone
-        assert {:error, _} = LazyConfig.builder(%{slug: "global:x"})
+        assert {:error, _} = LazyConfig.builder(%{my_slug: "global:x"})
 
         # "local:..." still works — LocalDerives still in the per-module opt
-        assert {:ok, _} = LazyConfig.builder(%{slug: "local:x"})
+        assert {:ok, _} = LazyConfig.builder(%{my_slug: "local:x"})
       after
         # The outer setup's on_exit will restore the original; we just
         # restore the test's expected value here so subsequent tests in

--- a/test/derive_test.exs
+++ b/test/derive_test.exs
@@ -843,4 +843,234 @@ defmodule GuardedStructTest.DeriveTest do
 
     "0" = assert ValidationDerive.validate(:some_string_integer, "0", :test)
   end
+
+  describe "list hygiene sanitizers" do
+    test ":uniq removes duplicates while preserving order" do
+      assert SanitizerDerive.sanitize([1, 2, 2, 3, 1], :uniq) == [1, 2, 3]
+    end
+
+    test ":uniq passes non-list through" do
+      assert SanitizerDerive.sanitize("hi", :uniq) == "hi"
+    end
+
+    test ":compact drops nils" do
+      assert SanitizerDerive.sanitize([1, nil, 2, nil], :compact) == [1, 2]
+    end
+
+    test ":reject_empty drops nil, empty string, empty list, empty map" do
+      assert SanitizerDerive.sanitize([1, "", nil, [], %{}, "ok"], :reject_empty) == [1, "ok"]
+    end
+
+    test ":sort sorts a list of comparables" do
+      assert SanitizerDerive.sanitize([3, 1, 2], :sort) == [1, 2, 3]
+    end
+  end
+
+  describe "string hygiene sanitizers" do
+    test ":squish collapses runs of whitespace and trims" do
+      assert SanitizerDerive.sanitize("  hello   world  ", :squish) == "hello world"
+    end
+
+    test ":no_control strips ASCII control characters" do
+      assert SanitizerDerive.sanitize("hi\x00there\x1F!", :no_control) == "hithere!"
+    end
+
+    test ":no_zero_width strips zero-width unicode chars" do
+      assert SanitizerDerive.sanitize("hi​there", :no_zero_width) == "hithere"
+    end
+
+    test "string-hygiene ops passthrough on non-binary" do
+      assert SanitizerDerive.sanitize(123, :squish) == 123
+      assert SanitizerDerive.sanitize(nil, :no_control) == nil
+    end
+  end
+
+  describe "clamp sanitizer" do
+    test "clamps below min" do
+      assert SanitizerDerive.sanitize(-5, {:clamp, [0, 100]}) == 0
+    end
+
+    test "clamps above max" do
+      assert SanitizerDerive.sanitize(200, {:clamp, [0, 100]}) == 100
+    end
+
+    test "leaves in-range untouched" do
+      assert SanitizerDerive.sanitize(50, {:clamp, [0, 100]}) == 50
+    end
+
+    test "works on floats" do
+      assert SanitizerDerive.sanitize(1.5, {:clamp, [0.0, 1.0]}) == 1.0
+    end
+
+    test "passthrough on non-number" do
+      assert SanitizerDerive.sanitize("hi", {:clamp, [0, 100]}) == "hi"
+    end
+  end
+
+  describe "default-fill sanitizers" do
+    test ":default_when_nil replaces nil" do
+      assert SanitizerDerive.sanitize(nil, {:default_when_nil, 42}) == 42
+    end
+
+    test ":default_when_nil leaves non-nil alone" do
+      assert SanitizerDerive.sanitize(7, {:default_when_nil, 42}) == 7
+    end
+
+    test ":default_when_empty handles nil, empty string, empty list, empty map" do
+      assert SanitizerDerive.sanitize(nil, {:default_when_empty, :x}) == :x
+      assert SanitizerDerive.sanitize("", {:default_when_empty, :x}) == :x
+      assert SanitizerDerive.sanitize([], {:default_when_empty, :x}) == :x
+      assert SanitizerDerive.sanitize(%{}, {:default_when_empty, :x}) == :x
+    end
+
+    test ":default_when_empty leaves non-empty alone" do
+      assert SanitizerDerive.sanitize("hi", {:default_when_empty, :x}) == "hi"
+      assert SanitizerDerive.sanitize([1], {:default_when_empty, :x}) == [1]
+    end
+  end
+
+  describe "named regex aliases" do
+    test ":slug accepts kebab-case lowercase" do
+      assert ValidationDerive.validate(:slug, "my-slug-1", :name) == "my-slug-1"
+    end
+
+    test ":slug rejects uppercase, underscores, leading/trailing dashes" do
+      assert {:error, :name, :slug, _} = ValidationDerive.validate(:slug, "MySlug", :name)
+      assert {:error, :name, :slug, _} = ValidationDerive.validate(:slug, "my_slug", :name)
+      assert {:error, :name, :slug, _} = ValidationDerive.validate(:slug, "-foo", :name)
+      assert {:error, :name, :slug, _} = ValidationDerive.validate(:slug, "foo-", :name)
+    end
+
+    test ":hostname accepts simple + subdomain forms" do
+      assert ValidationDerive.validate(:hostname, "example.com", :host) == "example.com"
+      assert ValidationDerive.validate(:hostname, "a.b.example.com", :host) == "a.b.example.com"
+    end
+
+    test ":hostname rejects underscore, scheme, length > 253" do
+      assert {:error, :host, :hostname, _} =
+               ValidationDerive.validate(:hostname, "bad_host.io", :host)
+
+      assert {:error, :host, :hostname, _} =
+               ValidationDerive.validate(:hostname, "https://example.com", :host)
+
+      long = String.duplicate("a", 254)
+
+      assert {:error, :host, :hostname, _} =
+               ValidationDerive.validate(:hostname, long, :host)
+    end
+
+    test ":port_number accepts 1..65535 integers" do
+      assert ValidationDerive.validate(:port_number, 1, :port) == 1
+      assert ValidationDerive.validate(:port_number, 65535, :port) == 65535
+      assert ValidationDerive.validate(:port_number, 8080, :port) == 8080
+    end
+
+    test ":port_number rejects out-of-range and non-integer" do
+      assert {:error, :port, :port_number, _} =
+               ValidationDerive.validate(:port_number, 0, :port)
+
+      assert {:error, :port, :port_number, _} =
+               ValidationDerive.validate(:port_number, 70000, :port)
+
+      assert {:error, :port, :port_number, _} =
+               ValidationDerive.validate(:port_number, "80", :port)
+    end
+
+    test ":hex_color accepts #RRGGBB and #RGB" do
+      assert ValidationDerive.validate(:hex_color, "#FF00aa", :color) == "#FF00aa"
+      assert ValidationDerive.validate(:hex_color, "#abc", :color) == "#abc"
+    end
+
+    test ":hex_color rejects missing hash, wrong length, bad chars" do
+      assert {:error, :color, :hex_color, _} =
+               ValidationDerive.validate(:hex_color, "FF0000", :color)
+
+      assert {:error, :color, :hex_color, _} =
+               ValidationDerive.validate(:hex_color, "#FF00", :color)
+
+      assert {:error, :color, :hex_color, _} =
+               ValidationDerive.validate(:hex_color, "#GG0000", :color)
+    end
+
+    test ":semver accepts basic + prerelease + build forms" do
+      assert ValidationDerive.validate(:semver, "1.2.3", :version) == "1.2.3"
+      assert ValidationDerive.validate(:semver, "1.0.0-alpha.1", :version) == "1.0.0-alpha.1"
+      assert ValidationDerive.validate(:semver, "1.0.0+build.42", :version) == "1.0.0+build.42"
+    end
+
+    test ":semver rejects malformed versions" do
+      assert {:error, :version, :semver, _} =
+               ValidationDerive.validate(:semver, "v1.2.3", :version)
+
+      assert {:error, :version, :semver, _} =
+               ValidationDerive.validate(:semver, "1.2", :version)
+
+      assert {:error, :version, :semver, _} =
+               ValidationDerive.validate(:semver, "1.2.3.4", :version)
+    end
+  end
+
+  describe "optional wrapper" do
+    test "nil passes through unchanged regardless of inner ops" do
+      assert nil == ValidationDerive.validate({:optional, [:string]}, nil, :f)
+      assert nil == ValidationDerive.validate({:optional, "string"}, nil, :f)
+      assert nil == ValidationDerive.validate({:optional, :string}, nil, :f)
+      assert nil == ValidationDerive.validate(%{optional: [:string, {:max_len, 5}]}, nil, :f)
+    end
+
+    test "non-nil value runs inner ops" do
+      assert "ok" == ValidationDerive.validate({:optional, [:string]}, "ok", :f)
+      assert "ok" == ValidationDerive.validate(%{optional: [:string, {:max_len, 5}]}, "ok", :f)
+    end
+
+    test "non-nil value fails when inner op rejects" do
+      assert {:error, :f, :string, _} =
+               ValidationDerive.validate({:optional, [:string]}, 42, :f)
+
+      assert {:error, :f, :max_len, _} =
+               ValidationDerive.validate(%{optional: [:string, {:max_len, 2}]}, "long", :f)
+    end
+  end
+
+  describe "each combinator — sanitize" do
+    test "applies inner sanitize ops to every element of a list" do
+      assert ["a", "b"] ==
+               SanitizerDerive.sanitize(["  A  ", "  B  "], %{each: [:trim, :downcase]})
+    end
+
+    test "tuple form (atoms-only inner list) also works" do
+      assert ["a", "b"] ==
+               SanitizerDerive.sanitize(["  A  ", "  B  "], {:each, [:trim, :downcase]})
+    end
+
+    test "passthrough on non-list input" do
+      assert "hi" == SanitizerDerive.sanitize("hi", %{each: [:downcase]})
+    end
+
+    test "empty list stays empty" do
+      assert [] == SanitizerDerive.sanitize([], %{each: [:trim]})
+    end
+  end
+
+  describe "each combinator — validate" do
+    test "every element passes inner ops → input returned unchanged" do
+      assert ["a", "b"] == ValidationDerive.validate(%{each: [:string]}, ["a", "b"], :tags)
+    end
+
+    test "any failing element makes the whole op error with indices" do
+      assert {:error, :tags, :each, msg} =
+               ValidationDerive.validate(%{each: [:string]}, ["a", 2, "c", 4], :tags)
+
+      assert msg =~ "failed indices: [1, 3]"
+    end
+
+    test "non-list input gets the generic :each error" do
+      assert {:error, :tags, :each, _} =
+               ValidationDerive.validate(%{each: [:string]}, "not-a-list", :tags)
+    end
+
+    test "tuple form (atoms-only inner list) also works" do
+      assert ["a"] == ValidationDerive.validate({:each, [:string]}, ["a"], :tags)
+    end
+  end
 end

--- a/test/fixtures/custom_derives_test.exs
+++ b/test/fixtures/custom_derives_test.exs
@@ -20,16 +20,16 @@ defmodule GuardedStructFixtures.CustomDerivesTest do
 
   describe "slugify sanitizer + slug validator (composed custom ops)" do
     test "slugify transforms the input; slug validator passes" do
-      # `:slug` has `derives: "sanitize(slugify) validate(slug)"`.
+      # `:my_slug` has `derives: "sanitize(slugify) validate(slug)"`.
       # `slugify` (custom sanitizer) downcases + replaces non-alnum
       # with hyphens, then `slug` (custom validator) accepts the result.
       assert {:ok, art} =
                CustomDerives.Article.builder(%{
                  title: "Hello, World!",
-                 slug: "Hello, World!"
+                 my_slug: "Hello, World!"
                })
 
-      assert art.slug == "hello-world"
+      assert art.my_slug == "hello-world"
     end
 
     test "slugify collapses runs of non-alphanumerics into single hyphens" do
@@ -38,19 +38,19 @@ defmodule GuardedStructFixtures.CustomDerivesTest do
       assert {:ok, art} =
                CustomDerives.Article.builder(%{
                  title: "x",
-                 slug: "  Mishka --- Group !! 2026  "
+                 my_slug: "  Mishka --- Group !! 2026  "
                })
 
-      assert art.slug == "mishka-group-2026"
+      assert art.my_slug == "mishka-group-2026"
     end
 
     test "slug validator rejects an empty/whitespace-only slug after slugify" do
       # ERROR REASON: slugify turns "!!!" into "" (all chars stripped),
       # then the `slug` validator (regex `^[a-z0-9][a-z0-9-]*$`) rejects
-      # the empty string → :slug action error.
-      assert {:error, errs} = CustomDerives.Article.builder(%{title: "x", slug: "!!!"})
+      # the empty string → :my_slug action error.
+      assert {:error, errs} = CustomDerives.Article.builder(%{title: "x", my_slug: "!!!"})
       errs = List.wrap(errs)
-      assert Enum.any?(errs, &(&1[:field] == :slug))
+      assert Enum.any?(errs, &(&1[:field] == :my_slug))
     end
   end
 
@@ -61,7 +61,7 @@ defmodule GuardedStructFixtures.CustomDerivesTest do
       assert {:error, errs} =
                CustomDerives.Article.builder(%{
                  title: "x",
-                 slug: "x",
+                 my_slug: "x",
                  views: -1
                })
 
@@ -74,7 +74,7 @@ defmodule GuardedStructFixtures.CustomDerivesTest do
       assert {:ok, %{views: 42}} =
                CustomDerives.Article.builder(%{
                  title: "x",
-                 slug: "x",
+                 my_slug: "x",
                  views: 42
                })
     end
@@ -83,7 +83,7 @@ defmodule GuardedStructFixtures.CustomDerivesTest do
       # `:views` has `default: 1`, which is > 0, so the validator
       # passes on the default.
       assert {:ok, %{views: 1}} =
-               CustomDerives.Article.builder(%{title: "x", slug: "x"})
+               CustomDerives.Article.builder(%{title: "x", my_slug: "x"})
     end
   end
 end

--- a/test/fixtures/records_test.exs
+++ b/test/fixtures/records_test.exs
@@ -491,8 +491,8 @@ defmodule GuardedStructFixtures.RecordsTest do
 
       user_meta = Enum.find(fields, &(&1.name == :user))
       assert user_meta.derive == "validate(record=user)"
-      # Parsed op is the tuple form {:record, "user"}.
-      assert %{validate: [{:record, "user"}]} = user_meta.__derive_ops__
+      # Tag atomized at compile time by OpEvaluator.
+      assert %{validate: [{:record, :user}]} = user_meta.__derive_ops__
 
       trace_meta = Enum.find(fields, &(&1.name == :trace))
       assert trace_meta.derive == "validate(record)"

--- a/test/global_test.exs
+++ b/test/global_test.exs
@@ -218,7 +218,7 @@ defmodule GuardedStructTest.GlobalTest do
            status: %{status: 2}
          },
          identity_provider: "google",
-         server: "users@mishka.tools"
+         server: "users@mishka.group"
        },
        age: 18,
        family: "Group",
@@ -227,7 +227,7 @@ defmodule GuardedStructTest.GlobalTest do
       assert TestNestedStruct.builder(%{
                username: " <p>Mishka   </p>",
                auth: %{
-                 server: "users@mishka.tools",
+                 server: "users@mishka.group",
                  identity_provider: "google",
                  role: %{
                    name: :user,
@@ -272,7 +272,7 @@ defmodule GuardedStructTest.GlobalTest do
       assert TestNestedStruct.builder(%{
                username: "mishka",
                auth: %{
-                 server: "users@mishka.tools",
+                 server: "users@mishka.group",
                  identity_provider: "google",
                  role: %{
                    name: :admin,

--- a/test/op_evaluator_test.exs
+++ b/test/op_evaluator_test.exs
@@ -1,0 +1,129 @@
+defmodule GuardedStructTest.OpEvaluatorTest do
+  use ExUnit.Case, async: true
+
+  alias GuardedStruct.Derive.OpEvaluator
+
+  describe "preevaluate/1 — nil + empty" do
+    test "nil passes through" do
+      assert nil == OpEvaluator.preevaluate(nil)
+    end
+
+    test "empty map passes through unchanged" do
+      assert %{} == OpEvaluator.preevaluate(%{})
+    end
+
+    test "ops without rewrite-eligible entries pass through" do
+      ops = %{validate: [:string, :not_empty], sanitize: [:trim]}
+      assert ^ops = OpEvaluator.preevaluate(ops)
+    end
+  end
+
+  describe "preevaluate/1 — :enum rewrites" do
+    test "String[a::b::c] resolves to string list" do
+      assert %{validate: [{:enum, ["a", "b", "c"]}]} =
+               OpEvaluator.preevaluate(%{validate: [{:enum, "String[a::b::c]"}]})
+    end
+
+    test "Atom[red::green::blue] resolves to atom list" do
+      assert %{validate: [{:enum, [:red, :green, :blue]}]} =
+               OpEvaluator.preevaluate(%{validate: [{:enum, "Atom[red::green::blue]"}]})
+    end
+
+    test "Integer[1::2::3] resolves to integer list" do
+      assert %{validate: [{:enum, [1, 2, 3]}]} =
+               OpEvaluator.preevaluate(%{validate: [{:enum, "Integer[1::2::3]"}]})
+    end
+
+    test "Float[1.5::2.5] resolves to float list" do
+      assert %{validate: [{:enum, [1.5, 2.5]}]} =
+               OpEvaluator.preevaluate(%{validate: [{:enum, "Float[1.5::2.5]"}]})
+    end
+  end
+
+  describe "preevaluate/1 — :equal rewrites" do
+    test "String::hello strips prefix" do
+      assert %{validate: [{:equal, "hello"}]} =
+               OpEvaluator.preevaluate(%{validate: [{:equal, "String::hello"}]})
+    end
+
+    test "Integer::42 parses to integer" do
+      assert %{validate: [{:equal, 42}]} =
+               OpEvaluator.preevaluate(%{validate: [{:equal, "Integer::42"}]})
+    end
+
+    test "Integer::bad leaves original string when parse fails" do
+      assert %{validate: [{:equal, "Integer::bad"}]} =
+               OpEvaluator.preevaluate(%{validate: [{:equal, "Integer::bad"}]})
+    end
+
+    test "Float::3.14 parses to float" do
+      assert %{validate: [{:equal, 3.14}]} =
+               OpEvaluator.preevaluate(%{validate: [{:equal, "Float::3.14"}]})
+    end
+
+    test "Atom::user atomizes the value" do
+      assert %{validate: [{:equal, :user}]} =
+               OpEvaluator.preevaluate(%{validate: [{:equal, "Atom::user"}]})
+    end
+  end
+
+  describe "preevaluate/1 — :record rewrite (#3 compile-time atomization)" do
+    test "binary tag is atomized" do
+      assert %{validate: [{:record, :user}]} =
+               OpEvaluator.preevaluate(%{validate: [{:record, "user"}]})
+    end
+
+    test "atom tag stays untouched" do
+      assert %{validate: [{:record, :user}]} =
+               OpEvaluator.preevaluate(%{validate: [{:record, :user}]})
+    end
+
+    test "bare :record (no tag) stays untouched" do
+      assert %{validate: [:record]} =
+               OpEvaluator.preevaluate(%{validate: [:record]})
+    end
+  end
+
+  describe "preevaluate/1 — :custom rewrite (#4 compile-time module resolution)" do
+    test "module-list + atom fun resolves to {Module, fun}" do
+      assert %{validate: [{:custom, {Enum, :sum}}]} =
+               OpEvaluator.preevaluate(%{validate: [{:custom, {[:Enum], :sum}}]})
+    end
+
+    test "nested module-list resolves to dotted module" do
+      assert %{validate: [{:custom, {String.Chars, :to_string}}]} =
+               OpEvaluator.preevaluate(%{
+                 validate: [{:custom, {[:String, :Chars], :to_string}}]
+               })
+    end
+
+    test "string form 'Mod,fn' resolves to {Module, atom_fn}" do
+      assert %{validate: [{:custom, {Enum, :sum}}]} =
+               OpEvaluator.preevaluate(%{validate: [{:custom, "Enum,sum"}]})
+    end
+
+    test "string form with brackets and spaces still resolves" do
+      assert %{validate: [{:custom, {Enum, :sum}}]} =
+               OpEvaluator.preevaluate(%{validate: [{:custom, "[Enum, sum]"}]})
+    end
+
+    test "string form without exactly 2 parts leaves original value" do
+      assert %{validate: [{:custom, "Enum"}]} =
+               OpEvaluator.preevaluate(%{validate: [{:custom, "Enum"}]})
+    end
+  end
+
+  describe "rewrite_tuple/1 — direct one-tuple rewrites (domain helper path)" do
+    test "rewrites :record binary tag" do
+      assert {:record, :user} = OpEvaluator.rewrite_tuple({:record, "user"})
+    end
+
+    test "rewrites :custom string form" do
+      assert {:custom, {Enum, :sum}} = OpEvaluator.rewrite_tuple({:custom, "Enum,sum"})
+    end
+
+    test "passes through unrecognised tuples unchanged" do
+      assert {:max_len, 20} = OpEvaluator.rewrite_tuple({:max_len, 20})
+    end
+  end
+end

--- a/test/op_param_validator_test.exs
+++ b/test/op_param_validator_test.exs
@@ -147,4 +147,89 @@ defmodule GuardedStructTest.OpParamValidatorTest do
       end
     end
   end
+
+  describe "validate!/3 — optional/each combinator inner ops" do
+    test "optional with registered atom inner passes" do
+      ops = %{validate: [{:optional, [:string]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "optional with parameterised tuple inner passes and cascades param-shape check" do
+      ops = %{validate: [{:optional, [:string, {:max_len, 20}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "optional map form with mixed atom and tuple inners passes" do
+      ops = %{validate: [%{optional: [:string, {:max_len, 20}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "optional with unknown atom inner raises with op name" do
+      assert_raise Spark.Error.DslError, ~r/unknown validate op :strng inside `optional`/, fn ->
+        OpParamValidator.validate!(%{validate: [{:optional, [:strng]}]}, :name, FakeMod)
+      end
+    end
+
+    test "optional with bad param inside known tuple inner raises (cascade)" do
+      assert_raise Spark.Error.DslError, ~r/invalid parameter for `max_len`/, fn ->
+        OpParamValidator.validate!(
+          %{validate: [{:optional, [:string, {:max_len, "bad"}]}]},
+          :name,
+          FakeMod
+        )
+      end
+    end
+
+    test "each (validate side) with registered atom inner passes" do
+      ops = %{validate: [{:each, [:string]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "each (validate side) with parameterised tuple inner passes and cascades" do
+      ops = %{validate: [{:each, [:string, {:max_len, 200}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "each (validate side) with unknown atom inner raises" do
+      assert_raise Spark.Error.DslError, ~r/unknown validate op :foo inside `each`/, fn ->
+        OpParamValidator.validate!(%{validate: [{:each, [:foo]}]}, :name, FakeMod)
+      end
+    end
+
+    test "each (validate side) with bad param inside known tuple inner raises (cascade)" do
+      assert_raise Spark.Error.DslError, ~r/invalid parameter for `max_len`/, fn ->
+        OpParamValidator.validate!(
+          %{validate: [{:each, [:string, {:max_len, "bad"}]}]},
+          :name,
+          FakeMod
+        )
+      end
+    end
+
+    test "each (sanitize side) with registered atom inners passes" do
+      ops = %{sanitize: [{:each, [:trim, :downcase]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "each (sanitize side) with unknown atom inner raises" do
+      assert_raise Spark.Error.DslError, ~r/unknown sanitize op :nope inside `each`/, fn ->
+        OpParamValidator.validate!(%{sanitize: [{:each, [:nope]}]}, :name, FakeMod)
+      end
+    end
+
+    test "each (sanitize side) with parameterised tuple inner passes and cascades" do
+      ops = %{sanitize: [{:each, [:trim, {:clamp, [0, 100]}]}]}
+      assert ^ops = OpParamValidator.validate!(ops, :name, FakeMod)
+    end
+
+    test "each (sanitize side) with bad param inside known tuple inner raises (cascade)" do
+      assert_raise Spark.Error.DslError, ~r/invalid parameter for `clamp`/, fn ->
+        OpParamValidator.validate!(
+          %{sanitize: [{:each, [:trim, {:clamp, [10, 0]}]}]},
+          :name,
+          FakeMod
+        )
+      end
+    end
+  end
 end

--- a/test/op_param_validator_test.exs
+++ b/test/op_param_validator_test.exs
@@ -102,7 +102,7 @@ defmodule GuardedStructTest.OpParamValidatorTest do
     end
 
     test "regex with integer raises" do
-      assert_raise Spark.Error.DslError, ~r/charlist or string/, fn ->
+      assert_raise Spark.Error.DslError, ~r/charlist, string, or compiled Regex/, fn ->
         OpParamValidator.validate!(%{validate: [{:regex, 42}]}, :name, FakeMod)
       end
     end

--- a/test/parser_string_form_test.exs
+++ b/test/parser_string_form_test.exs
@@ -1,0 +1,133 @@
+defmodule GuardedStructTest.ParserStringFormTest do
+  @moduledoc """
+  Unit tests for `GuardedStruct.Derive.Parser` covering the string-form
+  derive grammar: regex patterns, parameterised ops (`min_len=`,
+  `regex=`, `clamp=`), list-shaped ops (`each=`, `optional=`), and the
+  bare named aliases (`slug`, `hostname`, …).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias GuardedStruct.Derive.Parser
+
+  describe "parser/1 with regex= op" do
+    test "simple pattern parses to {:regex, binary}" do
+      assert %{validate: [{:regex, "^[a-z]+$"}]} =
+               Parser.parser("validate(regex=^[a-z]+$)")
+    end
+
+    test "pattern with hyphen-range and dot inside character class" do
+      assert %{validate: [{:regex, "^[a-z0-9.-]+$"}]} =
+               Parser.parser("validate(regex=^[a-z0-9.-]+$)")
+    end
+
+    test "pattern with uppercase, digits, dot, and hyphen" do
+      assert %{validate: [{:regex, "^[a-zA-Z0-9.-]+$"}]} =
+               Parser.parser("validate(regex=^[a-zA-Z0-9.-]+$)")
+    end
+
+    test "regex op mixed with sanitize and other validate ops keeps every op" do
+      derive_str =
+        "sanitize(trim, downcase) validate(string, not_empty, min_len=3, max_len=200, regex=^[a-z0-9.-]+$)"
+
+      assert %{
+               sanitize: [:trim, :downcase],
+               validate: [
+                 :string,
+                 :not_empty,
+                 {:min_len, 3},
+                 {:max_len, 200},
+                 {:regex, "^[a-z0-9.-]+$"}
+               ]
+             } = Parser.parser(derive_str)
+    end
+
+    test "literal-quoted regex pattern still works" do
+      assert %{validate: [{:regex, "^foo$"}]} =
+               Parser.parser(~S{validate(regex="^foo$")})
+    end
+
+    test "escaped-dot pattern from the global_test.exs fixture parses" do
+      input = "validate(regex=#{~c"^[a-zA-Z]+@mishka\\.group$"})"
+
+      assert %{validate: [{:regex, pattern}]} = Parser.parser(input)
+      assert is_binary(pattern)
+      assert pattern =~ "mishka"
+    end
+  end
+
+  describe "ValidationDerive end-to-end after parser fix" do
+    test "parsed regex op rejects non-matching input at validate-time" do
+      %{validate: ops} = Parser.parser("validate(regex=^[a-z]+$)")
+
+      {_first, errors} =
+        GuardedStruct.Derive.ValidationDerive.call({:slug, "bad_value"}, ops, [])
+
+      assert [%{field: :slug, action: :regex, message: msg}] = errors
+      assert msg =~ "Invalid format in the slug field"
+    end
+
+    test "parsed regex op accepts matching input" do
+      %{validate: ops} = Parser.parser("validate(regex=^[a-z]+$)")
+
+      {first, errors} =
+        GuardedStruct.Derive.ValidationDerive.call({:slug, "lowercase"}, ops, [])
+
+      assert first == "lowercase"
+      assert errors == []
+    end
+  end
+
+  describe "list/string hygiene sanitizers parse as bare atoms" do
+    test "list hygiene set" do
+      assert %{sanitize: [:uniq, :compact, :reject_empty, :sort]} =
+               Parser.parser("sanitize(uniq, compact, reject_empty, sort)")
+    end
+
+    test "string hygiene set" do
+      assert %{sanitize: [:squish, :no_control, :no_zero_width]} =
+               Parser.parser("sanitize(squish, no_control, no_zero_width)")
+    end
+  end
+
+  describe "parameterised sanitizer ops" do
+    test "clamp=[0, 100] parses to tuple form" do
+      assert %{sanitize: [{:clamp, [0, 100]}]} =
+               Parser.parser("sanitize(clamp=[0, 100])")
+    end
+
+    test "default_when_nil=0 parses to tuple form" do
+      assert %{sanitize: [{:default_when_nil, 0}]} =
+               Parser.parser("sanitize(default_when_nil=0)")
+    end
+  end
+
+  describe "named regex aliases parse as bare atoms" do
+    test "slug, hostname, port_number, hex_color, semver" do
+      assert %{validate: [:slug]} = Parser.parser("validate(slug)")
+      assert %{validate: [:hostname]} = Parser.parser("validate(hostname)")
+      assert %{validate: [:port_number]} = Parser.parser("validate(port_number)")
+      assert %{validate: [:hex_color]} = Parser.parser("validate(hex_color)")
+      assert %{validate: [:semver]} = Parser.parser("validate(semver)")
+    end
+  end
+
+  describe "each combinator" do
+    test "sanitize each=[trim, downcase] parses to map form" do
+      assert %{sanitize: [%{each: [:trim, :downcase]}]} =
+               Parser.parser("sanitize(each=[trim, downcase])")
+    end
+
+    test "validate each=[string, max_len=200] parses to map form" do
+      assert %{validate: [%{each: [:string, {:max_len, 200}]}]} =
+               Parser.parser("validate(each=[string, max_len=200])")
+    end
+  end
+
+  describe "optional wrapper" do
+    test "optional=[string, max_len=3] parses to map form" do
+      assert %{validate: [%{optional: [:string, {:max_len, 3}]}]} =
+               Parser.parser("validate(optional=[string, max_len=3])")
+    end
+  end
+end

--- a/test/parser_string_form_test.exs
+++ b/test/parser_string_form_test.exs
@@ -129,4 +129,35 @@ defmodule GuardedStructTest.ParserStringFormTest do
                Parser.parser("validate(optional=[string, max_len=3])")
     end
   end
+
+  # The bare-atom form (no brackets) is the one that used to materialise
+  # a binary inner op and force a String.to_existing_atom rescue at validate
+  # time. The parser now wraps it in a 1-element atom list so the runtime
+  # never has to atomize.
+  describe "optional / each — bare-atom value normalization" do
+    test "optional=string produces {:optional, [:string]} (atom, not binary)" do
+      assert %{validate: [{:optional, [:string]}]} =
+               Parser.parser("validate(optional=string)")
+    end
+
+    test "each=trim produces {:each, [:trim]} on sanitize side" do
+      assert %{sanitize: [{:each, [:trim]}]} =
+               Parser.parser("sanitize(each=trim)")
+    end
+
+    test "each=string produces {:each, [:string]} on validate side" do
+      assert %{validate: [{:each, [:string]}]} =
+               Parser.parser("validate(each=string)")
+    end
+
+    test "bracketed form produces map shape (all atoms)" do
+      assert %{validate: [%{each: [:string, :not_empty]}]} =
+               Parser.parser("validate(each=[string, not_empty])")
+    end
+
+    test "bracketed form with parameterised inner also produces map shape" do
+      assert %{validate: [%{each: [:string, {:max_len, 20}]}]} =
+               Parser.parser("validate(each=[string, max_len=20])")
+    end
+  end
 end

--- a/test/parser_string_form_test.exs
+++ b/test/parser_string_form_test.exs
@@ -11,18 +11,18 @@ defmodule GuardedStructTest.ParserStringFormTest do
   alias GuardedStruct.Derive.Parser
 
   describe "parser/1 with regex= op" do
-    test "simple pattern parses to {:regex, binary}" do
-      assert %{validate: [{:regex, "^[a-z]+$"}]} =
+    test "simple pattern parses to pre-compiled %Regex{}" do
+      assert %{validate: [{:regex, %Regex{source: "^[a-z]+$"}}]} =
                Parser.parser("validate(regex=^[a-z]+$)")
     end
 
     test "pattern with hyphen-range and dot inside character class" do
-      assert %{validate: [{:regex, "^[a-z0-9.-]+$"}]} =
+      assert %{validate: [{:regex, %Regex{source: "^[a-z0-9.-]+$"}}]} =
                Parser.parser("validate(regex=^[a-z0-9.-]+$)")
     end
 
     test "pattern with uppercase, digits, dot, and hyphen" do
-      assert %{validate: [{:regex, "^[a-zA-Z0-9.-]+$"}]} =
+      assert %{validate: [{:regex, %Regex{source: "^[a-zA-Z0-9.-]+$"}}]} =
                Parser.parser("validate(regex=^[a-zA-Z0-9.-]+$)")
     end
 
@@ -37,22 +37,21 @@ defmodule GuardedStructTest.ParserStringFormTest do
                  :not_empty,
                  {:min_len, 3},
                  {:max_len, 200},
-                 {:regex, "^[a-z0-9.-]+$"}
+                 {:regex, %Regex{source: "^[a-z0-9.-]+$"}}
                ]
              } = Parser.parser(derive_str)
     end
 
     test "literal-quoted regex pattern still works" do
-      assert %{validate: [{:regex, "^foo$"}]} =
+      assert %{validate: [{:regex, %Regex{source: "^foo$"}}]} =
                Parser.parser(~S{validate(regex="^foo$")})
     end
 
     test "escaped-dot pattern from the global_test.exs fixture parses" do
       input = "validate(regex=#{~c"^[a-zA-Z]+@mishka\\.group$"})"
 
-      assert %{validate: [{:regex, pattern}]} = Parser.parser(input)
-      assert is_binary(pattern)
-      assert pattern =~ "mishka"
+      assert %{validate: [{:regex, %Regex{} = regex}]} = Parser.parser(input)
+      assert Regex.source(regex) =~ "mishka"
     end
   end
 

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -1,0 +1,67 @@
+defmodule GuardedStructTest.RegistryTest do
+  use ExUnit.Case, async: true
+
+  alias GuardedStruct.Derive.Registry
+
+  describe "validate_ops/0 + known_validate?/1" do
+    test "includes the core type guards" do
+      ops = Registry.validate_ops()
+      for name <- [:string, :integer, :atom, :map, :list, :boolean, :float],
+          do: assert(MapSet.member?(ops, name), "missing core: #{name}")
+    end
+
+    test "includes the named-format validators added on this branch" do
+      for name <- [:slug, :hostname, :port_number, :hex_color, :semver] do
+        assert Registry.known_validate?(name), "missing format: #{name}"
+      end
+    end
+
+    test "includes the combinator op atoms (optional + each)" do
+      assert Registry.known_validate?(:optional)
+      assert Registry.known_validate?(:each)
+    end
+
+    test "rejects atoms that are sanitize-only" do
+      refute Registry.known_validate?(:trim)
+      refute Registry.known_validate?(:downcase)
+      refute Registry.known_validate?(:squish)
+    end
+
+    test "rejects unknown atoms" do
+      refute Registry.known_validate?(:not_a_real_op)
+      refute Registry.known_validate?(:strng)
+    end
+  end
+
+  describe "sanitize_ops/0 + known_sanitize?/1" do
+    test "includes the legacy core sanitizers" do
+      for name <- [:trim, :upcase, :downcase, :capitalize, :strip_tags] do
+        assert Registry.known_sanitize?(name), "missing core sanitizer: #{name}"
+      end
+    end
+
+    test "includes the list hygiene sanitizers added on this branch" do
+      for name <- [:uniq, :compact, :reject_empty, :sort] do
+        assert Registry.known_sanitize?(name), "missing list sanitizer: #{name}"
+      end
+    end
+
+    test "includes the string hygiene sanitizers added on this branch" do
+      for name <- [:squish, :no_control, :no_zero_width] do
+        assert Registry.known_sanitize?(name), "missing string sanitizer: #{name}"
+      end
+    end
+
+    test "includes the parameterised sanitizers added on this branch" do
+      for name <- [:clamp, :default_when_nil, :default_when_empty, :each] do
+        assert Registry.known_sanitize?(name), "missing parameterised sanitizer: #{name}"
+      end
+    end
+
+    test "rejects atoms that are validate-only" do
+      refute Registry.known_sanitize?(:string)
+      refute Registry.known_sanitize?(:not_empty)
+      refute Registry.known_sanitize?(:slug)
+    end
+  end
+end

--- a/test/support/fixtures/custom_derives.ex
+++ b/test/support/fixtures/custom_derives.ex
@@ -6,7 +6,7 @@ defmodule GuardedStructFixtures.CustomDerives do
     * `use GuardedStruct.Derive.Extension`
     * `validator :name, fun` — declarative validator op
     * `sanitizer :name, fun` — declarative sanitizer op that transforms input
-    * Composing two custom ops on one field: `sanitize(slugify) validate(slug)`
+    * Composing two custom ops on one field: `sanitize(slugify) validate(my_slug)`
 
   Activated by `:derive_extensions` config; see `test/fixtures_test.exs`
   for the wiring.
@@ -16,7 +16,7 @@ defmodule GuardedStructFixtures.CustomDerives do
     use GuardedStruct.Derive.Extension
 
     derives do
-      validator :slug, fn input ->
+      validator :my_slug, fn input ->
         is_binary(input) and Regex.match?(~r/^[a-z0-9][a-z0-9-]*$/, input)
       end
 
@@ -38,9 +38,9 @@ defmodule GuardedStructFixtures.CustomDerives do
       field(:title, String.t(), enforce: true, derives: "validate(string, not_empty)")
 
       # Composed custom ops:
-      field(:slug, String.t(),
+      field(:my_slug, String.t(),
         enforce: true,
-        derives: "sanitize(slugify) validate(slug)"
+        derives: "sanitize(slugify) validate(my_slug)"
       )
 
       field(:views, integer(), default: 1, derives: "validate(positive_int)")

--- a/test/support/fixtures/extracted/derive_extension.ex
+++ b/test/support/fixtures/extracted/derive_extension.ex
@@ -2,7 +2,7 @@ defmodule GuardedStructTest.Fixtures.DeriveExtension.SlugDerives do
   use GuardedStruct.Derive.Extension
 
   derives do
-    validator :slug, fn input ->
+    validator :my_slug, fn input ->
       is_binary(input) and Regex.match?(~r/^[a-z0-9-]+$/, input)
     end
 
@@ -19,7 +19,7 @@ defmodule GuardedStructTest.Fixtures.DeriveExtension.WithSlug do
   use GuardedStruct
 
   guardedstruct do
-    field :slug, String.t(), derives: "validate(slug)"
+    field :my_slug, String.t(), derives: "validate(my_slug)"
   end
 end
 
@@ -27,6 +27,6 @@ defmodule GuardedStructTest.Fixtures.DeriveExtension.WithSlugify do
   use GuardedStruct
 
   guardedstruct do
-    field :slug, String.t(), derives: "sanitize(slugify) validate(slug)"
+    field :my_slug, String.t(), derives: "sanitize(slugify) validate(my_slug)"
   end
 end

--- a/usage-rules/derive.md
+++ b/usage-rules/derive.md
@@ -31,6 +31,17 @@ docs), but the string form above is the canonical input.
 | `:basic_html` / `:html5` / `:markdown_html` | Whitelisted HTML cleanup (optional dep). |
 | `{:tag, op_atom}` | `trim → op → trim`. |
 | `:string_float` / `:string_integer` | Parse numeric out of a string; returns `0`/`0.0` on failure. |
+| `:squish` | Collapse runs of whitespace into a single space + trim. Binaries only. |
+| `:no_control` | Strip ASCII control characters (`\x00`–`\x1F`, `\x7F`). Binaries only. |
+| `:no_zero_width` | Strip zero-width unicode (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`, `U+2060`). |
+| `:uniq` | `Enum.uniq/1` on lists; passthrough otherwise. |
+| `:compact` | Drop `nil` entries from a list. |
+| `:reject_empty` | Drop `nil`, `""`, `[]`, `%{}` entries from a list. |
+| `:sort` | `Enum.sort/1` on lists. |
+| `{:clamp, [min, max]}` | Clamp a number to `min..max`. Numbers only; passthrough otherwise. |
+| `{:default_when_nil, value}` | Replace `nil` with `value`. |
+| `{:default_when_empty, value}` | Replace `nil` / `""` / `[]` / `%{}` with `value`. |
+| `{:each, [ops]}` | Apply inner sanitize ops to every element of a list. |
 
 Arg order is **pipe-friendly**: `SanitizerDerive.sanitize(value, :op)`.
 
@@ -51,9 +62,16 @@ Content / format:
 | `:url`, `:tell`, `:geo_url` | URL/phone/geo via `URL`/`ExPhoneNumber` (optional). |
 | `:uuid`, `:ipv4`, `:datetime`, `:date`, `:range`, `:regex` | Format checks. |
 | `:username`, `:full_name`, `:location`, `:queue`, `:string_boolean` | Domain checks (see `lib/guarded_struct/helper/extra.ex`). |
+| `:slug` | `^[a-z0-9]+(-[a-z0-9]+)*$` — kebab-case URL slug. |
+| `:hostname` | RFC-style hostname (no scheme, ≤ 253 chars). |
+| `:port_number` | Integer in `1..65535`. |
+| `:hex_color` | `#RGB` or `#RRGGBB` form. |
+| `:semver` | `MAJOR.MINOR.PATCH[-prerelease][+build]`. |
 | `{:enum, "String[a::b::c]"}` etc. | Membership against compile-evaluated list. |
 | `{:equal, _}` | Equality. |
 | `{:either, _}`, `{:custom, _}` | Composition / user-supplied predicate. |
+| `{:optional, _}` | Wrap any inner op; nil passes, non-nil runs the inner ops. |
+| `{:each, [ops]}` | Apply inner validate ops to every element of a list; error message includes failing indices. |
 | `:record` | Erlang record shape. |
 
 ## Op flow
@@ -72,6 +90,26 @@ Content / format:
 * Pipe form via `GuardedStruct.Sanitize` / `GuardedStruct.Validate` helpers.
 
 All five normalize to the same internal op map.
+
+## Combinator patterns
+
+```elixir
+field :allowed_origins, {:array, :string},
+  derives: "sanitize(each=[trim, downcase], reject_empty, uniq) validate(list, max_len=20, each=[string, hostname])"
+
+field :frontend_domain, :string,
+  derives: "sanitize(trim, downcase) validate(optional=[string, max_len=200, hostname])"
+
+field :priority, :integer,
+  derives: "sanitize(default_when_nil=0, clamp=[0, 100])"
+
+field :brand_color, :string,
+  derives: "sanitize(trim, squish) validate(string, hex_color)"
+
+field :api_port, :integer, derives: "validate(port_number)"
+```
+
+When combining `each=[...]` with `max_len=N` on the same list, declare `max_len` **before** `each` so the size check runs first and bounds the work `each` does.
 
 ## Direct API
 


### PR DESCRIPTION
- [x] Check what places we can move in to compile time? something like this `lib/guarded_struct/derive/validation_derive.ex`
- [x] Check what place has rescue and change it, especially if it is inside runtime and in loop